### PR TITLE
fix(ci): reformat readme for ruff 0.16, pin linter upper bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ pip install secretscreen
 from secretscreen import redact_pair, redact_dict, audit_dict, Mode
 
 # Single pair
-redact_pair("DB_PASSWORD", "hunter2")        # → "[REDACTED]"
-redact_pair("APP_NAME", "myapp")             # → "myapp"
+redact_pair("DB_PASSWORD", "hunter2")  # → "[REDACTED]"
+redact_pair("APP_NAME", "myapp")  # → "myapp"
 
 # Dict with recursion
 redact_dict({"db": {"password": "x", "host": "localhost"}})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-cov>=5.0", "ruff>=0.4", "mypy>=1.10"]
+# Linters gate CI, so they carry upper bounds: an unpinned ruff minor bump
+# (0.15 -> 0.16) silently changed formatting rules and broke an unrelated PR.
+dev = ["pytest>=7.0", "pytest-cov>=5.0", "ruff>=0.4,<0.17", "mypy>=1.10,<3"]
 
 [project.urls]
 Homepage = "https://github.com/featurecreep-cron/secretscreen"


### PR DESCRIPTION
Unblocks #16, which is approved and mergeable but red on `lint`.

## What was failing

`ruff check src/ tests/` passes. The failing step is `ruff format --check .`, and it fails on **README.md**, not a Python file:

```
unformatted: File would be reformatted
  --> README.md:1:1
   - redact_pair("DB_PASSWORD", "hunter2")        # → "[REDACTED]"
   + redact_pair("DB_PASSWORD", "hunter2")  # → "[REDACTED]"
1 file would be reformatted, 19 files already formatted
```

ruff 0.16.0 formats Python code blocks inside Markdown, and collapses the hand-aligned inline comments in the quick-start block to a single two-space gap.

## Why now, and why #16 is not at fault

| | |
|---|---|
| Last green CI on `main` | 2026-07-18 |
| ruff 0.16.0 released | 2026-07-23 19:10 UTC |
| #16 CI run | 2026-07-26, installed ruff 0.16.0 |

#16 only changes four workflow YAML files. `main` would fail identically if CI ran on it today — it simply has not run since 18 July. Reproduced locally with ruff 0.16.0 pinned to match CI.

## Root cause

The `ruff>=0.4` dev extra was unpinned, so a minor bump changed the formatting contract silently and surfaced on an unrelated PR. Linters that gate CI now carry upper bounds (`ruff>=0.4,<0.17`, `mypy>=1.10,<3`) — mypy was already resolving to 2.x from `>=1.10`, same hazard.

Accepting the formatter rather than fighting it: the README change is cosmetic, and freezing on an old ruff minor to preserve manual alignment costs more than it saves.

## Verification

With ruff 0.16.0 locally: `ruff format --check .` clean (20 files), `ruff check` clean, `mypy src/` clean, 147 tests pass.