### PR TITLE
perf+fix: detection hot paths, security audit findings, size-cap fail-open

### DIFF
--- a/docs/audits/security-audit-2026-04-05.md
+++ b/docs/audits/security-audit-2026-04-05.md
@@ -39,11 +39,13 @@ redact_pair("config", crafted_json)
 import json
 from secretscreen import redact_pair
 
+
 def nested_json(depth, key, val):
     d = {key: val}
     for _ in range(depth):
         d = {"x": d}
     return json.dumps(d)
+
 
 payload = nested_json(1000, "cookie", "session_abc123xyz")  # ~7KB
 result = redact_pair("config", payload)
@@ -73,6 +75,7 @@ audit_pair("config", '{"password": "sup3r_s3cr3t"}')
 **Proof of concept**:
 ```python
 from secretscreen import audit_pair
+
 finding = audit_pair("config", '{"password": "sup3r_s3cr3t"}')
 print(finding._parsed_pairs)  # (('password', 'sup3r_s3cr3t'),)
 ```
@@ -100,9 +103,10 @@ matches_key_pattern("cookie_secret_url")
 **Proof of concept**:
 ```python
 from secretscreen._keys import matches_key_pattern
-matches_key_pattern("cookie_secret_url")     # → None (should be "secret")
-matches_key_pattern("credential_url")        # → None
-matches_key_pattern("password_token_url")    # → None
+
+matches_key_pattern("cookie_secret_url")  # → None (should be "secret")
+matches_key_pattern("credential_url")  # → None
+matches_key_pattern("password_token_url")  # → None
 ```
 
 **Impact**: Keys containing both a dangerous substring and a safe suffix bypass Layer 1 entirely. If the value also lacks a recognizable format (Layer 3), the secret passes through.
@@ -121,6 +125,18 @@ matches_key_pattern("password_token_url")    # → None
 
 **Fix**: Add a size cap at the top of `_detect` (before any layer), returning early for values exceeding a reasonable maximum (e.g., 1MB).
 
+**Correction (2026-07-27)**: The fix as prescribed above was wrong and was implemented as
+written. Returning early *before any layer* skips Layer 1, which matches on the key name and
+never touches the value — so `AWS_SECRET_ACCESS_KEY=<2MB blob>` passed through completely
+unredacted and `audit_pair` reported no finding. Trading a 7.7s CPU stall for a silent secret
+leak is the wrong direction for a redaction library.
+
+The cap now gates Layers 2–5 only; Layer 1 always runs. Residual gap, accepted and tested
+(`test_oversized_value_under_non_denylisted_key_is_a_known_gap`): an oversized value under a key
+that Layer 1 does not match — including safe-suffix keys like `DATABASE_URL`, which depend on
+Layer 4's value scan — is not scanned and passes through. Callers that print values must surface
+the skip rather than let unscanned output look screened.
+
 ---
 
 ### [MEDIUM-4] redact_dict/audit_dict crash on deeply nested dicts — `_core.py:296`
@@ -132,6 +148,7 @@ matches_key_pattern("password_token_url")    # → None
 **Proof of concept**:
 ```python
 from secretscreen import redact_dict
+
 data = {}
 current = data
 for _ in range(1000):

--- a/docs/audits/security-audit-2026-04-05.md
+++ b/docs/audits/security-audit-2026-04-05.md
@@ -1,0 +1,206 @@
+# Security Audit Report — 2026-04-05
+
+## Summary
+
+| | Critical | High | Medium | Low |
+|--|----------|------|--------|-----|
+| **Found** | 0 | 1 | 4 | 3 |
+
+- **Language/Framework**: Python 3.11-3.13, pure library (no network surface)
+- **Files Audited**: 14 / 14 (all source + CI/CD)
+- **Scope**: deep
+- **Focus**: all
+
+---
+
+## Findings
+
+### [HIGH-1] Detection bypass via deeply nested JSON — `_parsers.py:155`
+
+**Category**: Logic / Detection bypass
+**CVSS estimate**: 7.1
+**Description**: `_flatten` in `_parsers.py` recurses unboundedly into nested dicts/lists. At ~1000 levels of nesting (~7KB payload, well under the 64KB cap), Python raises `RecursionError`. The bare `except Exception` in `extract_pairs` silently swallows it and returns `[]`. With no pairs extracted, structured parsing is skipped. If the value doesn't match a gitleaks format pattern, the secret passes through unredacted.
+
+**Data flow**:
+```
+redact_pair("config", crafted_json)
+  → _detect(depth=0)
+  → extract_pairs(value)
+  → _parse_json → json.loads (succeeds)
+  → _flatten(data) → RecursionError
+  → caught by bare except → pairs = []
+  → structured parsing skipped
+  → format detection on raw JSON string → no match
+  → return original value unredacted
+```
+
+**Proof of concept**:
+```python
+import json
+from secretscreen import redact_pair
+
+def nested_json(depth, key, val):
+    d = {key: val}
+    for _ in range(depth):
+        d = {"x": d}
+    return json.dumps(d)
+
+payload = nested_json(1000, "cookie", "session_abc123xyz")  # ~7KB
+result = redact_pair("config", payload)
+assert payload == result  # passes — secret unredacted
+```
+
+**Impact**: An adversary who controls the structure of data being screened can reliably suppress detection. Affects logging/audit pipelines where secretscreen is used to sanitize output.
+
+**Fix**: Add a depth parameter to `_flatten` with a cap (e.g., 50). When exceeded, return pairs collected so far rather than raising. Alternatively, use iterative flattening with an explicit stack.
+
+---
+
+### [MEDIUM-1] Secret plaintext exposed in Finding._parsed_pairs — `_core.py:42`
+
+**Category**: Data exposure
+**CVSS estimate**: 5.3
+**Description**: When `audit_pair`/`audit_dict` fires via structured parsing, the returned `Finding` carries `_parsed_pairs` containing all extracted key-value pairs — including the plaintext secret. The leading underscore is convention, not access control. Any caller that logs or serializes Finding objects leaks the secret the library was meant to detect.
+
+**Data flow**:
+```
+audit_pair("config", '{"password": "sup3r_s3cr3t"}')
+  → _detect → structured parsing
+  → Finding(_parsed_pairs=(("password","sup3r_s3cr3t"),))
+  → returned to caller → logged/serialized
+```
+
+**Proof of concept**:
+```python
+from secretscreen import audit_pair
+finding = audit_pair("config", '{"password": "sup3r_s3cr3t"}')
+print(finding._parsed_pairs)  # (('password', 'sup3r_s3cr3t'),)
+```
+
+**Impact**: Audit consumers that serialize findings inadvertently log the secrets secretscreen detected.
+
+**Fix**: Exclude `_parsed_pairs` from the dataclass `__repr__` and `__str__`. Consider making it truly private by not exposing it on the Finding at all — pass it through the internal call chain instead (e.g., return a tuple of (Finding, cached_pairs) from _detect, consumed only by _apply_redaction).
+
+---
+
+### [MEDIUM-2] Safe suffix swallows subsequent dangerous patterns — `_keys.py:109`
+
+**Category**: Logic / Detection bypass
+**CVSS estimate**: 5.0
+**Description**: `matches_key_pattern` iterates patterns in declaration order. When the first matching pattern triggers a safe-suffix hit, the function returns `None` immediately — without checking subsequent patterns. A key like `cookie_secret_url` matches `cookie` first, hits the `_url` safe suffix, and returns `None` — never reaching the `secret` pattern.
+
+**Data flow**:
+```
+matches_key_pattern("cookie_secret_url")
+  → pattern "cookie" matches (index 9)
+  → safe suffix "_url" matches → return None
+  → pattern "secret" (index 13) never checked
+```
+
+**Proof of concept**:
+```python
+from secretscreen._keys import matches_key_pattern
+matches_key_pattern("cookie_secret_url")     # → None (should be "secret")
+matches_key_pattern("credential_url")        # → None
+matches_key_pattern("password_token_url")    # → None
+```
+
+**Impact**: Keys containing both a dangerous substring and a safe suffix bypass Layer 1 entirely. If the value also lacks a recognizable format (Layer 3), the secret passes through.
+
+**Fix**: Change logic: if *any* matching pattern has no safe-suffix override, return that pattern. Only return None if *all* matching patterns are overridden by safe suffixes.
+
+---
+
+### [MEDIUM-3] No size cap before format detection — `_formats.py:104`
+
+**Category**: Denial of service
+**CVSS estimate**: 4.8
+**Description**: `MAX_PARSE_LENGTH = 65536` guards only `extract_pairs`. `matches_known_format` has no size limit — it runs keyword scans and up to 221 regex matches on arbitrarily large inputs. At 50MB, this takes ~7.7s per call.
+
+**Impact**: In hot-path usage (middleware, log processors), an adversary controlling input values can cause thread starvation.
+
+**Fix**: Add a size cap at the top of `_detect` (before any layer), returning early for values exceeding a reasonable maximum (e.g., 1MB).
+
+---
+
+### [MEDIUM-4] redact_dict/audit_dict crash on deeply nested dicts — `_core.py:296`
+
+**Category**: Denial of service
+**CVSS estimate**: 4.3
+**Description**: `_redact_recursive` and `_audit_recursive` recurse on Python dicts/lists without depth guards. Unlike `_detect` (which has `_MAX_DETECT_DEPTH = 3`), these functions are unbounded. A dict nested ~1000 levels deep causes uncaught `RecursionError`.
+
+**Proof of concept**:
+```python
+from secretscreen import redact_dict
+data = {}
+current = data
+for _ in range(1000):
+    current["x"] = {}
+    current = current["x"]
+current["leaf"] = "val"
+redact_dict(data)  # raises RecursionError
+```
+
+**Impact**: Crashes the calling process. Unlike Finding HIGH-1, this is not caught — it propagates.
+
+**Fix**: Add a depth parameter to `_redact_recursive` and `_audit_recursive` with a reasonable cap (e.g., 100). Return the value unmodified when exceeded.
+
+---
+
+### [LOW-1] JDBC URLs bypass credential detection — `_urls.py:17`
+
+**Category**: Detection bypass (edge case)
+**Description**: `has_url_credentials` uses `urlsplit`, which parses `jdbc:postgresql://user:pass@host/db` with scheme `jdbc` and treats the rest as opaque. `parsed.password` is `None`. Common in Docker Compose files via `SPRING_DATASOURCE_URL`.
+
+**Fix**: Pre-strip known URL prefixes (`jdbc:`, `odbc:`) before parsing.
+
+---
+
+### [LOW-2] IPv6 URL redaction produces invalid URLs — `_urls.py:39`
+
+**Category**: Output correctness
+**Description**: `redact_url_password` uses `parsed.hostname` which strips IPv6 brackets. The reconstructed URL is invalid for IPv6 addresses.
+
+**Fix**: Re-add brackets when hostname contains `:`.
+
+---
+
+### [LOW-3] Non-str values pass through unredacted — `_core.py:84`
+
+**Category**: Type handling
+**Description**: `redact_pair` returns non-str values (bytes, int) unchanged. The return type annotation says `str`. Edge case — env vars are always str — but parsed YAML can produce bytes.
+
+**Fix**: Convert bytes to str before detection, or document the limitation.
+
+---
+
+### CI/CD Findings (validated against current main)
+
+**CI/CD-1: INVALIDATED** — Actions pinning (Critical). All actions are pinned to commit SHAs on current main. The agent read stale local files.
+
+**CI/CD-2: CONFIRMED (Medium)** — Dependabot auto-merge has no CI gate. `dependabot-automerge.yml` enables auto-merge for all dependabot PRs without checking CI status. GitHub's auto-merge feature respects branch protection required checks *if configured*, but this is a defense-in-depth gap. Dependabot cooldowns (30d/7d/3d) partially mitigate by delaying compromised version adoption.
+
+**CI/CD-3: CONFIRMED (Medium)** — `id-token: write` at workflow level in publish.yml. Grants OIDC capability to `pip install build` step, not just the publish step. If a build dependency is compromised, it could request an OIDC token and publish directly. Fix: split into two jobs — build (no id-token) and publish (id-token: write).
+
+**CI/CD-4: LOW** — CodeQL `security-events: write` on fork PRs. Low practical impact.
+
+---
+
+## Attack Surface Summary
+
+- **Entry points**: `redact_pair`, `redact_dict`, `audit_pair`, `audit_dict` — all accept arbitrary strings from callers
+- **Auth boundaries**: None (pure library)
+- **Trust boundaries**: Caller-provided key-value pairs are untrusted input; vendored gitleaks.toml is trusted
+
+## Recommendations
+
+1. Add depth guard to `_flatten` (HIGH-1 fix)
+2. Remove `_parsed_pairs` from Finding dataclass — pass through internal call chain only (MEDIUM-1 fix)
+3. Fix safe-suffix logic to check all matching patterns (MEDIUM-2 fix)
+4. Add global size cap in `_detect` (MEDIUM-3 fix)
+5. Add depth guard to `_redact_recursive` / `_audit_recursive` (MEDIUM-4 fix)
+6. Split publish.yml into build + publish jobs (CI/CD-3 fix)
+
+## Files Audited
+
+All 6 source modules, `__init__.py`, 6 test files, 5 workflow files, `pyproject.toml`, `dependabot.yml`, `SECURITY.md` — complete coverage.

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -181,8 +181,13 @@ def audit_dict(
 # Prevents stack overflow from crafted nested JSON/Python literals.
 _MAX_DETECT_DEPTH = 3
 
-# Maximum value length for detection. Values beyond this are likely data dumps,
-# not config values. Prevents DoS via large inputs hitting 221+ regex patterns.
+# Maximum value length for the value-scanning layers (2-5). Values beyond this
+# are likely data dumps, not config values. Prevents DoS via large inputs hitting
+# 221+ regex patterns. Layer 1 (key-name match) is deliberately exempt: it reads
+# only the key, so an oversized value under a secret-named key is still redacted.
+# Residual gap: an oversized value under an innocuous key name is not scanned and
+# passes through unredacted. Callers that print values (e.g. a CLI) should surface
+# that skip rather than let it look screened.
 _MAX_DETECT_LENGTH = 1_048_576  # 1 MB
 
 
@@ -196,14 +201,15 @@ def _detect(
     _redact_structured can reuse parsed pairs without re-parsing.
     The public API (audit_pair) strips the tuple before returning.
     """
-    if len(value) > _MAX_DETECT_LENGTH:
-        return None
+    oversized = len(value) > _MAX_DETECT_LENGTH
 
-    # Layer 1: Key-name pattern match
+    # Layer 1: Key-name pattern match. Runs even when oversized — it reads the key,
+    # not the value, so it costs nothing and still catches SECRET_KEY=<huge blob>.
     matched_pattern = matches_key_pattern(key, config.patterns, config.safe_suffixes)
     if matched_pattern is not None:
-        # URL keys get partial redaction, not full
-        if key.lower().endswith("_url") and has_url_credentials(value):
+        # URL keys get partial redaction, not full. Skipped when oversized:
+        # partial redaction has to scan the value, and a 50 MB URL is not a URL.
+        if not oversized and key.lower().endswith("_url") and has_url_credentials(value):
             return Finding(
                 key=key,
                 reason=f"key_pattern:{matched_pattern}",
@@ -215,6 +221,10 @@ def _detect(
             reason=f"key_pattern:{matched_pattern}",
             layer="key_pattern",
         )
+
+    # Layers 2-5 all scan the value itself. Stop here for oversized input.
+    if oversized:
+        return None
 
     # Layer 4: URL credential detection (even without key pattern match)
     if has_url_credentials(value):

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -39,6 +39,7 @@ class Finding:
     reason: str
     layer: str
     detail: str = ""
+    _parsed_pairs: tuple[tuple[str, str], ...] | None = None
 
 
 @dataclass
@@ -217,6 +218,7 @@ def _detect(key: str, value: str, config: ScreenConfig, _depth: int = 0) -> Find
                     reason=f"structured:{sub_key}={sub_finding.reason}",
                     layer="structured_parsing",
                     detail=f"Found secret in parsed structure: {sub_key}",
+                    _parsed_pairs=tuple(pairs),
                 )
 
     # Layer 3: Value-format detection (gitleaks patterns)
@@ -253,19 +255,24 @@ def _apply_redaction(finding: Finding, key: str, value: str, config: ScreenConfi
         return redact_url_password(value, config.replacement)
 
     if finding.layer == "structured_parsing":
-        return _redact_structured(value, config)
+        return _redact_structured(value, config, finding._parsed_pairs)
 
     return config.replacement
 
 
-def _redact_structured(value: str, config: ScreenConfig) -> str:
+def _redact_structured(
+    value: str,
+    config: ScreenConfig,
+    cached_pairs: tuple[tuple[str, str], ...] | None = None,
+) -> str:
     """Redact secret portions within a structured value string.
 
-    Re-parses the value and replaces only exact secret values, tracking
+    Uses pre-parsed pairs from detection when available to avoid
+    re-parsing the value. Replaces only exact secret values, tracking
     which values have been replaced to avoid collateral damage when a
     secret string appears as a substring of a non-secret value.
     """
-    pairs = extract_pairs(value)
+    pairs = list(cached_pairs) if cached_pairs else extract_pairs(value)
     # Collect secret values and their replacements
     secrets_to_redact: dict[str, str] = {}
     for sub_key, sub_value in pairs:

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -39,7 +39,6 @@ class Finding:
     reason: str
     layer: str
     detail: str = ""
-    _parsed_pairs: tuple[tuple[str, str], ...] | None = None
 
 
 @dataclass
@@ -92,11 +91,16 @@ def redact_pair(
         entropy_threshold=entropy_threshold,
     )
 
-    finding = _detect(key, value, config)
-    if finding is None:
+    result = _detect(key, value, config)
+    if result is None:
         return value
 
-    return _apply_redaction(finding, key, value, config)
+    if isinstance(result, tuple):
+        finding, cached_pairs = result
+    else:
+        finding, cached_pairs = result, None
+
+    return _apply_redaction(finding, key, value, config, cached_pairs)
 
 
 def redact_dict(
@@ -144,7 +148,10 @@ def audit_pair(
         safe_suffixes=safe_suffixes,
         entropy_threshold=entropy_threshold,
     )
-    return _detect(key, value, config)
+    result = _detect(key, value, config)
+    if isinstance(result, tuple):
+        return result[0]
+    return result
 
 
 def audit_dict(
@@ -174,9 +181,23 @@ def audit_dict(
 # Prevents stack overflow from crafted nested JSON/Python literals.
 _MAX_DETECT_DEPTH = 3
 
+# Maximum value length for detection. Values beyond this are likely data dumps,
+# not config values. Prevents DoS via large inputs hitting 221+ regex patterns.
+_MAX_DETECT_LENGTH = 1_048_576  # 1 MB
 
-def _detect(key: str, value: str, config: ScreenConfig, _depth: int = 0) -> Finding | None:
-    """Run all detection layers on a single key-value pair."""
+
+def _detect(
+    key: str, value: str, config: ScreenConfig, _depth: int = 0
+) -> Finding | None | tuple[Finding, list[tuple[str, str]]]:
+    """Run all detection layers on a single key-value pair.
+
+    When called internally (from _redact_recursive/_apply_redaction), returns
+    a (Finding, cached_pairs) tuple for structured parsing hits so that
+    _redact_structured can reuse parsed pairs without re-parsing.
+    The public API (audit_pair) strips the tuple before returning.
+    """
+    if len(value) > _MAX_DETECT_LENGTH:
+        return None
 
     # Layer 1: Key-name pattern match
     matched_pattern = matches_key_pattern(key, config.patterns, config.safe_suffixes)
@@ -211,15 +232,16 @@ def _detect(key: str, value: str, config: ScreenConfig, _depth: int = 0) -> Find
         pairs = []
     if pairs:
         for sub_key, sub_value in pairs:
-            sub_finding = _detect(sub_key, sub_value, config, _depth + 1)
+            sub_result = _detect(sub_key, sub_value, config, _depth + 1)
+            sub_finding = sub_result[0] if isinstance(sub_result, tuple) else sub_result
             if sub_finding is not None:
-                return Finding(
+                finding = Finding(
                     key=key,
                     reason=f"structured:{sub_key}={sub_finding.reason}",
                     layer="structured_parsing",
                     detail=f"Found secret in parsed structure: {sub_key}",
-                    _parsed_pairs=tuple(pairs),
                 )
+                return (finding, pairs)
 
     # Layer 3: Value-format detection (gitleaks patterns)
     format_match = matches_known_format(value)
@@ -245,7 +267,13 @@ def _detect(key: str, value: str, config: ScreenConfig, _depth: int = 0) -> Find
     return None
 
 
-def _apply_redaction(finding: Finding, key: str, value: str, config: ScreenConfig) -> str:
+def _apply_redaction(
+    finding: Finding,
+    key: str,
+    value: str,
+    config: ScreenConfig,
+    cached_pairs: list[tuple[str, str]] | None = None,
+) -> str:
     """Apply the appropriate redaction strategy based on finding layer.
 
     Single source of truth for layer-specific redaction behavior.
@@ -255,7 +283,7 @@ def _apply_redaction(finding: Finding, key: str, value: str, config: ScreenConfi
         return redact_url_password(value, config.replacement)
 
     if finding.layer == "structured_parsing":
-        return _redact_structured(value, config, finding._parsed_pairs)
+        return _redact_structured(value, config, cached_pairs)
 
     return config.replacement
 
@@ -263,7 +291,7 @@ def _apply_redaction(finding: Finding, key: str, value: str, config: ScreenConfi
 def _redact_structured(
     value: str,
     config: ScreenConfig,
-    cached_pairs: tuple[tuple[str, str], ...] | None = None,
+    cached_pairs: list[tuple[str, str]] | None = None,
 ) -> str:
     """Redact secret portions within a structured value string.
 
@@ -272,7 +300,7 @@ def _redact_structured(
     which values have been replaced to avoid collateral damage when a
     secret string appears as a substring of a non-secret value.
     """
-    pairs = list(cached_pairs) if cached_pairs else extract_pairs(value)
+    pairs = cached_pairs if cached_pairs else extract_pairs(value)
     # Collect secret values and their replacements
     secrets_to_redact: dict[str, str] = {}
     for sub_key, sub_value in pairs:
@@ -293,29 +321,40 @@ def _redact_structured(
     return redacted
 
 
+_MAX_RECURSIVE_DEPTH = 100
+
+
 def _redact_recursive(
     data: object,
     config: ScreenConfig,
+    _depth: int = 0,
 ) -> object:
     """Recursively walk and redact a nested structure."""
+    if _depth >= _MAX_RECURSIVE_DEPTH:
+        return data
+
     if isinstance(data, dict):
         out: dict[object, object] = {}
         for k, v in data.items():
             key_str = str(k)
             if isinstance(v, str):
-                finding = _detect(key_str, v, config)
-                if finding is not None:
-                    out[k] = _apply_redaction(finding, key_str, v, config)
+                result = _detect(key_str, v, config)
+                if result is not None:
+                    if isinstance(result, tuple):
+                        finding, cached_pairs = result
+                    else:
+                        finding, cached_pairs = result, None
+                    out[k] = _apply_redaction(finding, key_str, v, config, cached_pairs)
                 else:
                     out[k] = v
             elif isinstance(v, (dict, list)):
-                out[k] = _redact_recursive(v, config)
+                out[k] = _redact_recursive(v, config, _depth + 1)
             else:
                 out[k] = v
         return out
 
     if isinstance(data, list):
-        return [_redact_recursive(item, config) for item in data]
+        return [_redact_recursive(item, config, _depth + 1) for item in data]
 
     return data
 
@@ -324,18 +363,23 @@ def _audit_recursive(
     data: object,
     config: ScreenConfig,
     findings: list[Finding],
+    _depth: int = 0,
 ) -> None:
     """Recursively walk and audit a nested structure."""
+    if _depth >= _MAX_RECURSIVE_DEPTH:
+        return
+
     if isinstance(data, dict):
         for k, v in data.items():
             key_str = str(k)
             if isinstance(v, str):
-                finding = _detect(key_str, v, config)
+                result = _detect(key_str, v, config)
+                finding = result[0] if isinstance(result, tuple) else result
                 if finding is not None:
                     findings.append(finding)
             elif isinstance(v, (dict, list)):
-                _audit_recursive(v, config, findings)
+                _audit_recursive(v, config, findings, _depth + 1)
 
     elif isinstance(data, list):
         for item in data:
-            _audit_recursive(item, config, findings)
+            _audit_recursive(item, config, findings, _depth + 1)

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -91,14 +91,9 @@ def redact_pair(
         entropy_threshold=entropy_threshold,
     )
 
-    result = _detect(key, value, config)
-    if result is None:
+    finding, cached_pairs = _detect_with_pairs(key, value, config)
+    if finding is None:
         return value
-
-    if isinstance(result, tuple):
-        finding, cached_pairs = result
-    else:
-        finding, cached_pairs = result, None
 
     return _apply_redaction(finding, key, value, config, cached_pairs)
 
@@ -148,10 +143,7 @@ def audit_pair(
         safe_suffixes=safe_suffixes,
         entropy_threshold=entropy_threshold,
     )
-    result = _detect(key, value, config)
-    if isinstance(result, tuple):
-        return result[0]
-    return result
+    return _detect(key, value, config)
 
 
 def audit_dict(
@@ -191,15 +183,22 @@ _MAX_DETECT_DEPTH = 3
 _MAX_DETECT_LENGTH = 1_048_576  # 1 MB
 
 
-def _detect(
-    key: str, value: str, config: ScreenConfig, _depth: int = 0
-) -> Finding | None | tuple[Finding, list[tuple[str, str]]]:
+def _detect(key: str, value: str, config: ScreenConfig, _depth: int = 0) -> Finding | None:
     """Run all detection layers on a single key-value pair.
 
-    When called internally (from _redact_recursive/_apply_redaction), returns
-    a (Finding, cached_pairs) tuple for structured parsing hits so that
-    _redact_structured can reuse parsed pairs without re-parsing.
-    The public API (audit_pair) strips the tuple before returning.
+    For callers that only need the verdict. Redaction paths should use
+    _detect_with_pairs to avoid re-parsing structured values.
+    """
+    return _detect_with_pairs(key, value, config, _depth)[0]
+
+
+def _detect_with_pairs(
+    key: str, value: str, config: ScreenConfig, _depth: int = 0
+) -> tuple[Finding | None, list[tuple[str, str]] | None]:
+    """Run all detection layers, also returning parsed pairs on a structured hit.
+
+    _redact_structured reuses those pairs instead of parsing the value a second
+    time. The pairs are None for every other layer and for a clean value.
     """
     oversized = len(value) > _MAX_DETECT_LENGTH
 
@@ -210,29 +209,38 @@ def _detect(
         # URL keys get partial redaction, not full. Skipped when oversized:
         # partial redaction has to scan the value, and a 50 MB URL is not a URL.
         if not oversized and key.lower().endswith("_url") and has_url_credentials(value):
-            return Finding(
+            return (
+                Finding(
+                    key=key,
+                    reason=f"key_pattern:{matched_pattern}",
+                    layer="url_credentials",
+                    detail="URL with embedded credentials",
+                ),
+                None,
+            )
+        return (
+            Finding(
                 key=key,
                 reason=f"key_pattern:{matched_pattern}",
-                layer="url_credentials",
-                detail="URL with embedded credentials",
-            )
-        return Finding(
-            key=key,
-            reason=f"key_pattern:{matched_pattern}",
-            layer="key_pattern",
+                layer="key_pattern",
+            ),
+            None,
         )
 
     # Layers 2-5 all scan the value itself. Stop here for oversized input.
     if oversized:
-        return None
+        return (None, None)
 
     # Layer 4: URL credential detection (even without key pattern match)
     if has_url_credentials(value):
-        return Finding(
-            key=key,
-            reason="url_credentials",
-            layer="url_credentials",
-            detail="URL with embedded credentials",
+        return (
+            Finding(
+                key=key,
+                reason="url_credentials",
+                layer="url_credentials",
+                detail="URL with embedded credentials",
+            ),
+            None,
         )
 
     # Layer 2: Structured value parsing (depth-limited to prevent recursion bombs)
@@ -242,8 +250,7 @@ def _detect(
         pairs = []
     if pairs:
         for sub_key, sub_value in pairs:
-            sub_result = _detect(sub_key, sub_value, config, _depth + 1)
-            sub_finding = sub_result[0] if isinstance(sub_result, tuple) else sub_result
+            sub_finding = _detect(sub_key, sub_value, config, _depth + 1)
             if sub_finding is not None:
                 finding = Finding(
                     key=key,
@@ -256,25 +263,31 @@ def _detect(
     # Layer 3: Value-format detection (gitleaks patterns)
     format_match = matches_known_format(value)
     if format_match is not None:
-        return Finding(
-            key=key,
-            reason=f"format:{format_match.id}",
-            layer="format_detection",
-            detail=format_match.description,
+        return (
+            Finding(
+                key=key,
+                reason=f"format:{format_match.id}",
+                layer="format_detection",
+                detail=format_match.description,
+            ),
+            None,
         )
 
     # Layer 5: Entropy detection (aggressive mode only)
     if config.mode == Mode.AGGRESSIVE:
         entropy = looks_like_secret(value, config.entropy_threshold)
         if entropy is not None:
-            return Finding(
-                key=key,
-                reason=f"entropy:{entropy:.2f}",
-                layer="entropy",
-                detail=f"Shannon entropy {entropy:.2f} bits/char exceeds threshold",
+            return (
+                Finding(
+                    key=key,
+                    reason=f"entropy:{entropy:.2f}",
+                    layer="entropy",
+                    detail=f"Shannon entropy {entropy:.2f} bits/char exceeds threshold",
+                ),
+                None,
             )
 
-    return None
+    return (None, None)
 
 
 def _apply_redaction(
@@ -348,12 +361,8 @@ def _redact_recursive(
         for k, v in data.items():
             key_str = str(k)
             if isinstance(v, str):
-                result = _detect(key_str, v, config)
-                if result is not None:
-                    if isinstance(result, tuple):
-                        finding, cached_pairs = result
-                    else:
-                        finding, cached_pairs = result, None
+                finding, cached_pairs = _detect_with_pairs(key_str, v, config)
+                if finding is not None:
                     out[k] = _apply_redaction(finding, key_str, v, config, cached_pairs)
                 else:
                     out[k] = v
@@ -383,8 +392,7 @@ def _audit_recursive(
         for k, v in data.items():
             key_str = str(k)
             if isinstance(v, str):
-                result = _detect(key_str, v, config)
-                finding = result[0] if isinstance(result, tuple) else result
+                finding = _detect(key_str, v, config)
                 if finding is not None:
                     findings.append(finding)
             elif isinstance(v, (dict, list)):

--- a/src/secretscreen/_entropy.py
+++ b/src/secretscreen/_entropy.py
@@ -24,14 +24,15 @@ DEFAULT_ENTROPY_THRESHOLD = 4.5
 MIN_ENTROPY_LENGTH = 20
 
 
-def shannon_entropy(value: str) -> float:
+def shannon_entropy(value: str, *, _stripped: str | None = None) -> float:
     """Calculate Shannon entropy in bits per character.
 
     Whitespace is stripped before calculation.
     Returns 0.0 for empty strings.
+
+    If _stripped is provided, uses it directly instead of re-stripping.
     """
-    # Strip all whitespace — spaces aren't informative for secret detection
-    chars = "".join(value.split())
+    chars = _stripped if _stripped is not None else "".join(value.split())
     length = len(chars)
 
     if length == 0:
@@ -59,7 +60,7 @@ def looks_like_secret(
     if len(chars) < min_length:
         return None
 
-    ent = shannon_entropy(value)
+    ent = shannon_entropy(value, _stripped=chars)
     if ent >= threshold:
         return ent
 

--- a/src/secretscreen/_formats.py
+++ b/src/secretscreen/_formats.py
@@ -54,12 +54,17 @@ def _prepare_regex(pattern: str) -> tuple[str, int]:
     return pattern, flags
 
 
-def _load_rules() -> tuple[FormatRule, ...]:
-    """Load and compile gitleaks rules from vendored TOML."""
+def _load_rules() -> tuple[tuple[FormatRule, ...], frozenset[str]]:
+    """Load and compile gitleaks rules from vendored TOML.
+
+    Returns (rules, all_keywords) where all_keywords is the union of
+    every keyword across all rules, used for cross-rule pre-filtering.
+    """
     toml_path = importlib.resources.files("secretscreen").joinpath("gitleaks.toml")
     data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
 
     rules: list[FormatRule] = []
+    all_kw: set[str] = set()
     for entry in data.get("rules", []):
         regex_str = entry.get("regex")
         if not regex_str:
@@ -74,40 +79,50 @@ def _load_rules() -> tuple[FormatRule, ...]:
         except re.error:
             continue  # skip genuinely malformed patterns
 
+        keywords = tuple(entry.get("keywords", ()))
+        all_kw.update(keywords)
         rules.append(
             FormatRule(
                 id=entry["id"],
                 description=entry.get("description", ""),
                 regex=compiled,
-                keywords=tuple(entry.get("keywords", ())),
+                keywords=keywords,
                 entropy=entry.get("entropy"),
                 secret_group=entry.get("secretGroup", 0),
             )
         )
 
-    return tuple(rules)
+    return tuple(rules), frozenset(all_kw)
 
 
 # Compiled once at import time.
-RULES: tuple[FormatRule, ...] = _load_rules()
+RULES: tuple[FormatRule, ...]
+_ALL_KEYWORDS: frozenset[str]
+RULES, _ALL_KEYWORDS = _load_rules()
 
 
 def matches_known_format(value: str) -> FormatRule | None:
     """Check if a value matches any known secret format.
 
     Returns the matching rule, or None.
-    Uses keyword pre-filtering for performance.
+    Uses a two-phase keyword pre-filter: first builds the set of keywords
+    present in the value (single pass), then checks per-rule intersection.
     """
     if len(value) < 8:
         return None  # too short for any meaningful format
 
     value_lower = value.lower()
 
+    # Single-pass keyword scan: find which keywords appear in this value.
+    # This replaces per-rule O(keywords × len(value)) substring scans
+    # with one O(all_keywords × len(value)) pass + O(1) set lookups per rule.
+    matched_keywords = {kw for kw in _ALL_KEYWORDS if kw in value_lower}
+
     for rule in RULES:
         # Keyword pre-filter: if the rule has keywords, at least one must
         # appear in the value (case-insensitive) before we bother with regex.
         if rule.keywords:
-            if not any(kw in value_lower for kw in rule.keywords):
+            if not matched_keywords.intersection(rule.keywords):
                 continue
 
         if rule.regex.search(value):

--- a/src/secretscreen/_keys.py
+++ b/src/secretscreen/_keys.py
@@ -94,17 +94,19 @@ def matches_key_pattern(
 
     Returns the matched pattern string, or None if no match.
     Keys ending with a safe suffix are excluded even if they match a pattern.
+
+    Pattern check runs first (common case: no match → early return).
+    Safe suffix check only runs when a pattern matches, avoiding
+    unnecessary suffix scans on the majority of non-secret keys.
     """
     key_lower = key.lower()
 
-    # Safe suffix check — catches prefixed variants like
-    # GF_AUTH_GENERIC_OAUTH_TOKEN_URL, PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED
-    for suffix in safe_suffixes:
-        if key_lower.endswith(suffix):
-            return None
-
     for pattern in patterns:
         if pattern in key_lower:
+            # Only check safe suffixes when we have a match
+            for suffix in safe_suffixes:
+                if key_lower.endswith(suffix):
+                    return None
             return pattern
 
     return None

--- a/src/secretscreen/_keys.py
+++ b/src/secretscreen/_keys.py
@@ -95,18 +95,16 @@ def matches_key_pattern(
     Returns the matched pattern string, or None if no match.
     Keys ending with a safe suffix are excluded even if they match a pattern.
 
-    Pattern check runs first (common case: no match → early return).
-    Safe suffix check only runs when a pattern matches, avoiding
-    unnecessary suffix scans on the majority of non-secret keys.
+    Safe suffix check runs once (not per-pattern). Pattern check runs first
+    (common case: no match → early return).
     """
     key_lower = key.lower()
 
+    # Check safe suffix once upfront
+    is_safe = any(key_lower.endswith(suffix) for suffix in safe_suffixes)
+
     for pattern in patterns:
         if pattern in key_lower:
-            # Only check safe suffixes when we have a match
-            for suffix in safe_suffixes:
-                if key_lower.endswith(suffix):
-                    return None
-            return pattern
+            return None if is_safe else pattern
 
     return None

--- a/src/secretscreen/_parsers.py
+++ b/src/secretscreen/_parsers.py
@@ -152,15 +152,25 @@ def _parse_ini(value: str) -> list[tuple[str, str]]:
     return pairs
 
 
-def _flatten(data: object, _prefix: str = "") -> list[tuple[str, str]]:
-    """Recursively flatten nested structures into key-value pairs."""
+_MAX_FLATTEN_DEPTH = 50
+
+
+def _flatten(data: object, _prefix: str = "", _depth: int = 0) -> list[tuple[str, str]]:
+    """Recursively flatten nested structures into key-value pairs.
+
+    Depth is capped at _MAX_FLATTEN_DEPTH to prevent RecursionError
+    on adversarial input. Returns pairs collected so far when exceeded.
+    """
+    if _depth >= _MAX_FLATTEN_DEPTH:
+        return []
+
     pairs: list[tuple[str, str]] = []
 
     if isinstance(data, dict):
         for k, v in data.items():
             key = f"{_prefix}.{k}" if _prefix else str(k)
             if isinstance(v, (dict, list)):
-                pairs.extend(_flatten(v, key))
+                pairs.extend(_flatten(v, key, _depth + 1))
             else:
                 pairs.append((key, str(v) if v is not None else ""))
 
@@ -168,7 +178,7 @@ def _flatten(data: object, _prefix: str = "") -> list[tuple[str, str]]:
         for i, item in enumerate(data):
             key = f"{_prefix}[{i}]" if _prefix else f"[{i}]"
             if isinstance(item, (dict, list)):
-                pairs.extend(_flatten(item, key))
+                pairs.extend(_flatten(item, key, _depth + 1))
             else:
                 pairs.append((key, str(item) if item is not None else ""))
 

--- a/src/secretscreen/_urls.py
+++ b/src/secretscreen/_urls.py
@@ -14,12 +14,26 @@ from urllib.parse import urlsplit, urlunsplit
 _DEFAULT_REPLACEMENT = "[REDACTED]"
 
 
+# Multi-scheme URL prefixes that wrap a standard URL.
+# urlsplit treats these as the scheme, making credentials invisible.
+_URL_WRAPPERS = ("jdbc:", "odbc:")
+
+
+def _strip_url_wrapper(value: str) -> str:
+    """Strip multi-scheme prefixes so urlsplit can parse credentials."""
+    lower = value.lower()
+    for prefix in _URL_WRAPPERS:
+        if lower.startswith(prefix):
+            return value[len(prefix) :]
+    return value
+
+
 def has_url_credentials(value: str) -> bool:
     """Check if a value contains a URL with embedded credentials."""
     if "://" not in value:
         return False
     try:
-        parsed = urlsplit(value)
+        parsed = urlsplit(_strip_url_wrapper(value))
         return bool(parsed.scheme and parsed.password)
     except (ValueError, AttributeError):
         return False
@@ -31,16 +45,21 @@ def redact_url_password(value: str, replacement: str = _DEFAULT_REPLACEMENT) -> 
     Preserves username, host, path, query, and fragment for debugging.
     """
     try:
-        parsed = urlsplit(value)
+        raw = _strip_url_wrapper(value)
+        prefix = value[: len(value) - len(raw)]  # preserve original prefix casing
+        parsed = urlsplit(raw)
         if not parsed.password:
             return value
 
         user = parsed.username or ""
         host = parsed.hostname or ""
+        # Re-add brackets for IPv6 addresses
+        if host and ":" in host:
+            host = f"[{host}]"
         port_str = f":{parsed.port}" if parsed.port else ""
         new_netloc = f"{user}:{replacement}@{host}{port_str}"
 
-        return urlunsplit(
+        return prefix + urlunsplit(
             (
                 parsed.scheme,
                 new_netloc,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -256,19 +256,21 @@ class TestSecurityFixes:
 
     def test_deeply_nested_json_does_not_bypass_detection(self) -> None:
         """HIGH-1: Deeply nested JSON should not suppress detection via RecursionError."""
-        import json
+        # Built by string concatenation, not json.dumps: the encoder recurses in C
+        # and blows the stack on 3.11 before the library is ever called, which would
+        # make this a test of json.dumps rather than of redact_pair.
+        payload = '{"x": ' * 1000 + '{"password": "deep_secret_value"}' + "}" * 1000
 
-        # Build JSON nested 1000 levels deep with a secret key
-        d: dict = {"password": "deep_secret_value"}
-        for _ in range(1000):
-            d = {"x": d}
-        payload = json.dumps(d)
-
-        # The structured parsing should either detect the secret (if within
-        # flatten depth) or at minimum not crash. The key "config" is innocuous
-        # so detection depends on structured parsing finding "password".
+        # The key "config" is innocuous, so detection depends on structured parsing
+        # reaching "password". Below the flatten depth cap it will not, but it must
+        # degrade to a pass-through rather than raising.
         result = redact_pair("config", payload)
         assert isinstance(result, str)  # didn't crash
+
+        # Same secret at a depth the parser does reach is still detected — otherwise
+        # this test would pass just as well against a no-op implementation.
+        shallow = '{"x": ' * 2 + '{"password": "deep_secret_value"}' + "}" * 2
+        assert "deep_secret_value" not in redact_pair("config", shallow)
 
     def test_finding_does_not_expose_secret_values(self) -> None:
         """MEDIUM-1: Finding objects should not contain plaintext secrets."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -251,6 +251,96 @@ class TestRecursionDepthGuard:
         assert "nested_secret" not in result
 
 
+class TestSecurityFixes:
+    """Regression tests for security audit findings (2026-04-05)."""
+
+    def test_deeply_nested_json_does_not_bypass_detection(self) -> None:
+        """HIGH-1: Deeply nested JSON should not suppress detection via RecursionError."""
+        import json
+
+        # Build JSON nested 1000 levels deep with a secret key
+        d: dict = {"password": "deep_secret_value"}
+        for _ in range(1000):
+            d = {"x": d}
+        payload = json.dumps(d)
+
+        # The structured parsing should either detect the secret (if within
+        # flatten depth) or at minimum not crash. The key "config" is innocuous
+        # so detection depends on structured parsing finding "password".
+        result = redact_pair("config", payload)
+        assert isinstance(result, str)  # didn't crash
+
+    def test_finding_does_not_expose_secret_values(self) -> None:
+        """MEDIUM-1: Finding objects should not contain plaintext secrets."""
+        finding = audit_pair("config", '{"password": "sup3r_s3cr3t"}')
+        assert finding is not None
+        # Check that the Finding has no field containing the secret
+        assert not hasattr(finding, "_parsed_pairs")
+        finding_str = str(finding)
+        assert "sup3r_s3cr3t" not in finding_str
+
+    def test_large_value_does_not_cause_dos(self) -> None:
+        """MEDIUM-3: Values over 1MB should be rejected early."""
+        large_value = "x" * 2_000_000  # 2MB
+        result = redact_pair("SOME_KEY", large_value)
+        assert result == large_value  # returned unchanged, not processed
+
+    def test_deeply_nested_dict_does_not_crash(self) -> None:
+        """MEDIUM-4: redact_dict should handle deeply nested dicts without RecursionError."""
+        data: dict = {}
+        current = data
+        for _ in range(500):
+            current["x"] = {}
+            current = current["x"]
+        current["leaf"] = "val"
+
+        result = redact_dict(data)
+        assert isinstance(result, dict)  # didn't crash
+
+    def test_deeply_nested_dict_audit_does_not_crash(self) -> None:
+        """MEDIUM-4: audit_dict should handle deeply nested dicts without RecursionError."""
+        data: dict = {}
+        current = data
+        for _ in range(500):
+            current["x"] = {}
+            current = current["x"]
+        current["password"] = "secret"
+
+        findings = audit_dict(data)
+        assert isinstance(findings, list)  # didn't crash
+
+    def test_jdbc_url_detected(self) -> None:
+        """LOW-1: JDBC URLs should detect embedded credentials."""
+        from secretscreen._urls import has_url_credentials
+
+        assert has_url_credentials("jdbc:postgresql://admin:S3cr3t@prod-db:5432/main") is True
+        assert has_url_credentials("jdbc:mysql://root:password@localhost:3306/app") is True
+
+    def test_jdbc_url_redacted(self) -> None:
+        """LOW-1: JDBC URLs should have passwords redacted."""
+        from secretscreen._urls import redact_url_password
+
+        result = redact_url_password("jdbc:postgresql://admin:S3cr3t@prod-db:5432/main")
+        assert "S3cr3t" not in result
+        assert "admin" in result
+        assert result.startswith("jdbc:")
+
+    def test_ipv6_url_redaction_valid(self) -> None:
+        """LOW-2: IPv6 URL redaction should produce valid URLs."""
+        from secretscreen._urls import redact_url_password
+
+        result = redact_url_password("redis://user:secret@[::1]:6379/0")
+        assert "secret" not in result
+        assert "[" in result  # brackets preserved
+        assert "::1" in result
+
+    def test_odbc_url_detected(self) -> None:
+        """LOW-1: ODBC URLs should also detect embedded credentials."""
+        from secretscreen._urls import has_url_credentials
+
+        assert has_url_credentials("odbc:postgresql://admin:pass@host/db") is True
+
+
 class TestRealWorldCases:
     """Scenarios from actual Docker environments."""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -280,10 +280,51 @@ class TestSecurityFixes:
         assert "sup3r_s3cr3t" not in finding_str
 
     def test_large_value_does_not_cause_dos(self) -> None:
-        """MEDIUM-3: Values over 1MB should be rejected early."""
+        """MEDIUM-3: Values over 1MB skip the value-scanning layers."""
         large_value = "x" * 2_000_000  # 2MB
         result = redact_pair("SOME_KEY", large_value)
         assert result == large_value  # returned unchanged, not processed
+
+    def test_large_value_under_secret_key_is_still_redacted(self) -> None:
+        """The size cap must not fail open: layer 1 reads the key, not the value.
+
+        Regression: the original MEDIUM-3 fix returned early before layer 1, so
+        AWS_SECRET_ACCESS_KEY=<2MB> passed through in full.
+        """
+        large_value = "x" * 2_000_000  # 2MB
+        assert redact_pair("AWS_SECRET_ACCESS_KEY", large_value) == "[REDACTED]"
+        assert redact_pair("DB_PASSWORD", large_value) == "[REDACTED]"
+
+    def test_large_value_under_secret_key_is_audited(self) -> None:
+        """audit_pair must report the oversized secret rather than reporting clean."""
+        finding = audit_pair("AWS_SECRET_ACCESS_KEY", "x" * 2_000_000)
+        assert finding is not None
+        assert finding.layer == "key_pattern"
+
+    def test_large_value_layer_one_is_cheap(self) -> None:
+        """Layer 1 on an oversized value must not fall through to the regex layers."""
+        import time
+
+        large_value = "x" * 20_000_000  # 20MB
+        start = time.perf_counter()
+        assert redact_pair("SECRET_KEY", large_value) == "[REDACTED]"
+        assert time.perf_counter() - start < 1.0
+
+    def test_oversized_value_under_non_denylisted_key_is_a_known_gap(self) -> None:
+        """Documents the residual size-cap gap rather than leaving it unstated.
+
+        Keys like DATABASE_URL carry a safe suffix ('_url'), so layer 1 never
+        matches them — they rely on layer 4, which scans the value and is
+        therefore skipped when oversized. Such values pass through unredacted.
+        Callers that print values must surface the skip; see _MAX_DETECT_LENGTH.
+        """
+        large_url = "postgres://user:pw@host/db?pad=" + "x" * 2_000_000
+        assert redact_pair("DATABASE_URL", large_url) == large_url
+        assert audit_pair("DATABASE_URL", large_url) is None
+
+        # Same URL under the cap is redacted normally.
+        small_url = "postgres://user:pw@host/db"
+        assert redact_pair("DATABASE_URL", small_url) == "postgres://user:[REDACTED]@host/db"
 
     def test_deeply_nested_dict_does_not_crash(self) -> None:
         """MEDIUM-4: redact_dict should handle deeply nested dicts without RecursionError."""


### PR DESCRIPTION
Lands the April security audit + perf work that has been sitting unmerged on `perf/detection-hotpath-optimizations`, minus that branch's CI commit, plus a fix for a fail-open bug the audit fix itself introduced.

## What's here

**`perf`** — cached structured parsing (pairs parsed during detection are reused for redaction instead of re-parsed) and a single-pass keyword scan.

**`fix`** — the [security audit](docs/audits/security-audit-2026-04-05.md) findings: depth guards on `_redact_recursive`/`_audit_recursive` (MEDIUM-4), a value size cap (MEDIUM-3), and data-exposure fixes.

**`fix`** — the size cap as originally prescribed *failed open*. The audit's own remediation text said to return early "at the top of `_detect`, before any layer," and that's what got implemented — but layer 1 matches on the **key name** and never reads the value. Result:

```python
redact_pair("AWS_SECRET_ACCESS_KEY", "x" * 2_000_000)  # returned all 2MB, unredacted
audit_pair("AWS_SECRET_ACCESS_KEY", "x" * 2_000_000)   # returned None — reported clean
```

Trading a 7.7s CPU stall for a silent secret leak is the wrong direction for a redaction library. The cap now gates layers 2–5 only; layer 1 always runs. A 50MB value under a secret-named key redacts in ~46ms.

**Residual gap** (accepted, tested, documented in the audit doc): an oversized value under a key layer 1 *doesn't* match — including safe-suffix keys like `DATABASE_URL`, which depend on layer 4's value scan — is still unscanned and passes through. Callers that print values need to surface that skip rather than let unscanned output look screened. That's a requirement on the CLI in #2, not something the library can fix without either re-introducing the DoS or destroying legitimate large payloads.

**`refactor`** — the caching change had left `_detect` returning `Finding | None | tuple[Finding, list]`, isinstance-checked at five call sites. Split into `_detect_with_pairs` (redaction paths) and `_detect` (audit paths). No behavior change.

## Verification

- 160 tests pass (147 on main + 13 new); `ruff check`, `ruff format --check`, `mypy src/` all clean
- Behavior spot-checked directly, not just via tests: oversized secret key, structured JSON, URL credentials, nested dict, 50MB timing

## Not included

`36454d5 fix(ci): add approve step to dependabot auto-merge workflow` from the original branch is deliberately dropped. Main has since reverted that line of work, and the actual root cause turned out to be a missing write permission on the automerge GitHub App, fixed Jul 18. Re-applying the old workaround risks breaking what currently works.