### PR TITLE
feat: format-aware CLI for redacting config-shaped data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,38 @@ findings = audit_dict(env)
 redact_dict(env, safe_suffixes=("_config", "_enabled"))
 ```
 
+## Command line
+
+The library only helps Python callers. The CLI covers the shell side — `docker exec`, Makefiles, CI logs, anything you are about to paste somewhere.
+
+```
+secretscreen tandoor.env                    # redact and print, cat-like
+docker exec app env | secretscreen          # scrub a stream before it hits your terminal
+secretscreen --audit config.json            # findings only, no values, exit 1 if any
+```
+
+```
+secretscreen [FILE...]              reads stdin when FILE is omitted or '-'
+  --audit                           report findings without values; exit 1 if any
+  --format env|json|ini|dsn|auto    default: auto-detect from extension, then content
+  --aggressive                      add entropy detection; more false positives
+  --replacement TEXT                default: [REDACTED]
+```
+
+Redaction is structural, not line-based: it parses the format, so it catches `DB_PASSWORD=hunter2` on the key name and rewrites `postgres://admin:s3cr3t@host/db` to `postgres://admin:[REDACTED]@host/db` without destroying the rest of the line. Comments, blank lines, quoting, `export` prefixes, INI sections and `:` separators all survive the round trip.
+
+**What the exit code means:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | Everything was parsed and screened |
+| 1 | `--audit` found secrets |
+| 2 | Something could not be parsed or read — see stderr |
+
+That third case is the one that matters. This is best-effort defense-in-depth, and a cat-replacement is exactly the tool people stop thinking about, so the CLI never prints unparsed content verbatim: a line it cannot structure is replaced with the redaction token, named on stderr, and turns the exit code non-zero. The same applies to values above the 1 MB detection cap — they are reported as unscanned rather than passed off as clean.
+
+If you are scanning a git repository rather than config-shaped data, use [gitleaks](https://github.com/gitleaks/gitleaks) instead. That is a different job.
+
 ## Detection layers
 
 1. **Key-name denylist** — substring match against ~30 known secret key patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "secretscreen"
-version = "0.1.0"
+version = "0.2.0"
 description = "Detect and redact secrets in key-value pairs, dicts, and environment variables."
 readme = "README.md"
 license = "MIT"
@@ -23,6 +23,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
+
+[project.scripts]
+secretscreen = "secretscreen._cli:main"
 
 [project.optional-dependencies]
 # Linters gate CI, so they carry upper bounds: an unpinned ruff minor bump

--- a/src/secretscreen/__init__.py
+++ b/src/secretscreen/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "redact_pair",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/secretscreen/_cli.py
+++ b/src/secretscreen/_cli.py
@@ -1,0 +1,265 @@
+"""Command-line interface — format-aware redaction of config-shaped data.
+
+    secretscreen tandoor.env           # redact and print, cat-like
+    docker exec app env | secretscreen --format env
+    secretscreen --audit config.json   # findings only, exit 1 if any
+
+Design constraint: the library is best-effort defense-in-depth, not a security
+boundary, and a cat-replacement is exactly the tool people stop thinking about.
+So the failure that matters here is not a false positive — it is silently
+printing content that was never structurally parsed, which looks screened and
+is not. Every such line is replaced with the redaction token, reported on
+stderr, and turns the exit code non-zero. Nothing unparsed reaches stdout
+verbatim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TYPE_CHECKING
+
+from secretscreen._core import (
+    _MAX_DETECT_LENGTH,
+    REDACTED,
+    Mode,
+    audit_dict,
+    audit_pair,
+    redact_dict,
+    redact_pair,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from secretscreen._core import Finding
+
+EXIT_OK = 0
+EXIT_FINDINGS = 1
+EXIT_ERROR = 2
+
+FORMATS = ("env", "json", "ini", "dsn", "auto")
+
+_JSON_EXTENSIONS = {".json"}
+_INI_EXTENSIONS = {".ini", ".cfg", ".conf", ".properties"}
+_ENV_EXTENSIONS = {".env", ".envrc"}
+
+# Separator characters by format, in precedence order.
+_SEPARATORS = {"env": ("=",), "ini": ("=", ":")}
+_COMMENT_PREFIXES = {"env": ("#",), "ini": ("#", ";")}
+
+
+class _Report:
+    """Accumulates findings and problems across all inputs.
+
+    Not a dataclass: the architecture tests require every dataclass in the
+    package to be frozen, and this is mutable by nature.
+    """
+
+    def __init__(self) -> None:
+        self.findings: list[tuple[str, int, Finding]] = []
+        self.problems: list[str] = []
+
+    def problem(self, source: str, lineno: int, message: str) -> None:
+        self.problems.append(f"{source}:{lineno}: {message}")
+
+
+def _strip_quotes(value: str) -> tuple[str, str]:
+    """Split a value into (quote_char, inner). Quote char is '' when unquoted."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[0], value[1:-1]
+    return "", value
+
+
+def _detect_format(text: str, filename: str | None) -> str:
+    """Pick a parser from the file extension, falling back to content sniffing."""
+    if filename:
+        lowered = filename.lower()
+        dot = lowered.rfind(".")
+        extension = lowered[dot:] if dot != -1 else ""
+        if extension in _JSON_EXTENSIONS:
+            return "json"
+        if extension in _INI_EXTENSIONS:
+            return "ini"
+        if extension in _ENV_EXTENSIONS or lowered.split("/")[-1].startswith(".env"):
+            return "env"
+
+    stripped = text.lstrip()
+    if stripped.startswith("{"):
+        return "json"
+    for line in text.splitlines():
+        bare = line.strip()
+        if bare.startswith("[") and bare.endswith("]"):
+            return "ini"
+    return "env"
+
+
+def _redact_value(key: str, value: str, mode: Mode, replacement: str) -> tuple[str, bool]:
+    """Redact one value. Returns (result, unscanned) — unscanned means the size cap hit."""
+    result = redact_pair(key, value, mode=mode, replacement=replacement)
+    unscanned = len(value) > _MAX_DETECT_LENGTH and result == value
+    return result, unscanned
+
+
+def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, report: _Report) -> list[str]:
+    """Redact a line-oriented format (env, ini), preserving comments and layout."""
+    separators = _SEPARATORS[fmt]
+    comments = _COMMENT_PREFIXES[fmt]
+    out: list[str] = []
+
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        stripped = raw.strip()
+
+        if not stripped or stripped.startswith(comments):
+            out.append(raw)
+            continue
+
+        if fmt == "ini" and stripped.startswith("[") and stripped.endswith("]"):
+            out.append(raw)
+            continue
+
+        positions = [raw.find(sep) for sep in separators if raw.find(sep) != -1]
+        if not positions:
+            # Structurally unparseable. Redact rather than echo it — an unparsed
+            # line is exactly the one we cannot vouch for.
+            report.problem(source, lineno, "no key=value separator; line redacted unscanned")
+            out.append(args.replacement)
+            continue
+
+        split_at = min(positions)
+        separator = raw[split_at]  # preserve ':' vs '=' rather than normalising
+        # `left` is echoed verbatim so that spacing and any `export ` prefix survive
+        # the round trip; only the detection key is normalised.
+        left, value = raw[:split_at], raw[split_at + 1 :]
+        key = left.strip()
+        if fmt == "env" and key.startswith("export "):
+            key = key[len("export ") :].strip()
+
+        quote, inner = _strip_quotes(value.strip())
+        leading = value[: len(value) - len(value.lstrip())]
+
+        if args.audit:
+            finding = audit_pair(key, inner, mode=args.mode)
+            if finding is not None:
+                report.findings.append((source, lineno, finding))
+            if len(inner) > _MAX_DETECT_LENGTH and finding is None:
+                report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
+            continue
+
+        redacted, unscanned = _redact_value(key, inner, args.mode, args.replacement)
+        if unscanned:
+            report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
+        out.append(f"{left}{separator}{leading}{quote}{redacted}{quote}")
+
+    return out
+
+
+def _process_json(text: str, source: str, args: argparse.Namespace, report: _Report) -> list[str]:
+    """Redact a JSON document by walking the parsed structure."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        report.problem(source, exc.lineno, f"invalid JSON ({exc.msg}); nothing printed")
+        return []
+
+    if args.audit:
+        for finding in audit_dict(data, mode=args.mode):
+            report.findings.append((source, 0, finding))
+        return []
+
+    redacted = redact_dict(data, mode=args.mode, replacement=args.replacement)
+    return json.dumps(redacted, indent=2).splitlines()
+
+
+def _process_dsn(text: str, source: str, args: argparse.Namespace, report: _Report) -> list[str]:
+    """Redact bare connection strings, one per line."""
+    out: list[str] = []
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        if not raw.strip():
+            out.append(raw)
+            continue
+        if args.audit:
+            finding = audit_pair("dsn", raw.strip(), mode=args.mode)
+            if finding is not None:
+                report.findings.append((source, lineno, finding))
+            continue
+        redacted, unscanned = _redact_value("dsn", raw.strip(), args.mode, args.replacement)
+        if unscanned:
+            report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
+        out.append(redacted)
+    return out
+
+
+def _read(path: str, report: _Report) -> str | None:
+    """Read a file or stdin, reporting IO problems rather than raising."""
+    if path == "-":
+        return sys.stdin.read()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        report.problem(path, 0, f"cannot read: {exc}")
+        return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="secretscreen",
+        description="Redact secrets from config-shaped data and print the result.",
+        epilog="Best-effort defense-in-depth, not a security boundary. "
+        "Lines that cannot be structurally parsed are redacted and reported on stderr.",
+    )
+    parser.add_argument("files", nargs="*", metavar="FILE", help="files to redact; reads stdin when omitted or '-'")
+    parser.add_argument("--audit", action="store_true", help="report findings without values; exit 1 if any are found")
+    parser.add_argument("--format", choices=FORMATS, default="auto", help="input format (default: auto-detect)")
+    parser.add_argument("--aggressive", action="store_true", help="add entropy detection; more false positives")
+    parser.add_argument("--replacement", default=REDACTED, help=f"replacement text (default: {REDACTED})")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point. Returns the process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    args.mode = Mode.AGGRESSIVE if args.aggressive else Mode.NORMAL
+
+    report = _Report()
+    sources = args.files or ["-"]
+    lines: list[str] = []
+
+    for path in sources:
+        text = _read(path, report)
+        if text is None:
+            continue
+
+        label = "<stdin>" if path == "-" else path
+        fmt = args.format if args.format != "auto" else _detect_format(text, None if path == "-" else path)
+
+        if fmt == "json":
+            lines.extend(_process_json(text, label, args, report))
+        elif fmt == "dsn":
+            lines.extend(_process_dsn(text, label, args, report))
+        else:
+            lines.extend(_process_lines(text, fmt, label, args, report))
+
+    if args.audit:
+        for source, lineno, finding in report.findings:
+            location = f"{source}:{lineno}" if lineno else source
+            print(f"{location}: {finding.key}: {finding.layer} ({finding.reason})")
+    else:
+        for line in lines:
+            print(line)
+
+    for problem in report.problems:
+        print(f"secretscreen: {problem}", file=sys.stderr)
+
+    if report.problems:
+        return EXIT_ERROR
+    if args.audit and report.findings:
+        return EXIT_FINDINGS
+    return EXIT_OK
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -267,6 +267,46 @@ class TestNoSideEffects:
         assert not violations, "Filesystem write in library module:\n" + "\n".join(violations)
 
 
+class TestVersionSync:
+    """pyproject version and __version__ must agree.
+
+    Nothing else enforces this, and a drift ships a wheel whose metadata
+    disagrees with the value the library reports at runtime.
+    """
+
+    def test_versions_match(self):
+        import tomllib
+
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        declared = tomllib.loads(pyproject.read_text())["project"]["version"]
+
+        tree = ast.parse((SRC / "__init__.py").read_text())
+        runtime = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "__version__":
+                        if isinstance(node.value, ast.Constant):
+                            runtime = node.value.value
+
+        assert runtime == declared, f"pyproject version {declared!r} != __version__ {runtime!r}"
+
+
+class TestCLIEntryPoint:
+    """The console script must point at something importable and callable."""
+
+    def test_entry_point_resolves(self):
+        import tomllib
+
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        scripts = tomllib.loads(pyproject.read_text())["project"]["scripts"]
+        assert scripts["secretscreen"] == "secretscreen._cli:main"
+
+        from secretscreen._cli import main
+
+        assert callable(main)
+
+
 class TestPublicAPI:
     """__init__.py exports exactly the intended public API.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,234 @@
+"""Tests for the command-line interface.
+
+The CLI's contract is narrower than the library's: whatever reaches stdout has
+been structurally parsed, and anything that has not been is both redacted and
+reported. Most of these tests exist to pin that down.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from secretscreen._cli import EXIT_ERROR, EXIT_FINDINGS, EXIT_OK, main
+
+SAMPLE_ENV = """\
+# comment
+APP_NAME=myapp
+DB_PASSWORD=hunter2
+DATABASE_URL=postgres://admin:s3cr3t@db.internal:5432/prod
+export API_TOKEN="ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+LOG_LEVEL=debug
+"""
+
+
+def _write(tmp_path, name: str, content: str) -> str:
+    path = tmp_path / name
+    path.write_text(content)
+    return str(path)
+
+
+class TestRedactMode:
+    """Default cat-like behaviour."""
+
+    def test_redacts_env_file(self, tmp_path, capsys) -> None:
+        code = main([_write(tmp_path, "sample.env", SAMPLE_ENV)])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_OK
+        assert "hunter2" not in out
+        assert "s3cr3t" not in out
+        assert "ghp_16C7e42F292c6912E7710c838347Ae178B4a" not in out
+        # Non-secrets survive untouched.
+        assert "APP_NAME=myapp" in out
+        assert "LOG_LEVEL=debug" in out
+
+    def test_preserves_comments_quotes_and_export(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "sample.env", SAMPLE_ENV)])
+        out = capsys.readouterr().out
+
+        assert "# comment" in out
+        assert 'export API_TOKEN="[REDACTED]"' in out
+
+    def test_preserves_spacing_around_separator(self, tmp_path, capsys) -> None:
+        """The left-hand side is echoed verbatim, not reconstructed."""
+        main([_write(tmp_path, "s.env", "SPACED =  value\n")])
+        assert "SPACED =  value" in capsys.readouterr().out
+
+    def test_partial_url_redaction_keeps_structure(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "sample.env", SAMPLE_ENV)])
+        out = capsys.readouterr().out
+        assert "postgres://admin:[REDACTED]@db.internal:5432/prod" in out
+
+    def test_custom_replacement(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "s.env", "DB_PASSWORD=hunter2\n"), "--replacement", "XXX"])
+        out = capsys.readouterr().out
+        assert "DB_PASSWORD=XXX" in out
+        assert "hunter2" not in out
+
+    def test_reads_stdin_when_no_file(self, capsys, monkeypatch) -> None:
+        monkeypatch.setattr("sys.stdin", _FakeStdin("DB_PASSWORD=hunter2\n"))
+        code = main([])
+        out = capsys.readouterr().out
+        assert code == EXIT_OK
+        assert "hunter2" not in out
+
+    def test_aggressive_mode_catches_high_entropy(self, tmp_path, capsys) -> None:
+        content = "OPAQUE=xQ7fJ2mNp9VzR4tLw8YbK3sHdG6aE5cU\n"
+        main([_write(tmp_path, "s.env", content), "--aggressive"])
+        assert "xQ7fJ2mNp9VzR4tLw8YbK3sHdG6aE5cU" not in capsys.readouterr().out
+
+
+class TestUnparseableInputFailsLoudly:
+    """The core safety property: nothing unparsed reaches stdout verbatim."""
+
+    def test_line_without_separator_is_redacted_and_reported(self, tmp_path, capsys) -> None:
+        code = main([_write(tmp_path, "s.env", "GOOD=1\nNOTAPAIR\n")])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_ERROR
+        assert "NOTAPAIR" not in captured.out
+        assert "[REDACTED]" in captured.out
+        assert "no key=value separator" in captured.err
+
+    def test_invalid_json_prints_nothing(self, tmp_path, capsys) -> None:
+        code = main([_write(tmp_path, "bad.json", '{"password": "hunter2"')])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_ERROR
+        assert captured.out == ""
+        assert "hunter2" not in captured.out
+        assert "invalid JSON" in captured.err
+
+    def test_unreadable_file_is_reported(self, tmp_path, capsys) -> None:
+        code = main([str(tmp_path / "does-not-exist.env")])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_ERROR
+        assert "cannot read" in captured.err
+
+    def test_oversized_value_is_reported_not_silently_passed(self, tmp_path, capsys) -> None:
+        """The size cap's residual gap must be visible, never silent."""
+        code = main([_write(tmp_path, "big.env", "DATA=" + "x" * 1_100_000 + "\n")])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_ERROR
+        assert "not scanned" in captured.err
+
+    def test_oversized_value_under_secret_key_is_still_redacted(self, tmp_path, capsys) -> None:
+        code = main([_write(tmp_path, "big.env", "DB_PASSWORD=" + "x" * 1_100_000 + "\n")])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_OK
+        assert "DB_PASSWORD=[REDACTED]" in captured.out
+        assert "xxxx" not in captured.out
+
+
+class TestAuditMode:
+    """Findings without values."""
+
+    def test_reports_findings_and_exits_one(self, tmp_path, capsys) -> None:
+        code = main([_write(tmp_path, "sample.env", SAMPLE_ENV), "--audit"])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_FINDINGS
+        assert "DB_PASSWORD" in out
+        assert "DATABASE_URL" in out
+
+    def test_never_prints_secret_values(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "sample.env", SAMPLE_ENV), "--audit"])
+        captured = capsys.readouterr()
+
+        for secret in ("hunter2", "s3cr3t", "ghp_16C7e42F292c6912E7710c838347Ae178B4a"):
+            assert secret not in captured.out
+            assert secret not in captured.err
+
+    def test_clean_input_exits_zero(self, tmp_path, capsys) -> None:
+        code = main([_write(tmp_path, "s.env", "APP=ok\nLOG=debug\n"), "--audit"])
+        assert code == EXIT_OK
+        assert capsys.readouterr().out == ""
+
+    def test_audit_does_not_print_redacted_content(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "s.env", "APP_NAME=myapp\nDB_PASSWORD=hunter2\n"), "--audit"])
+        assert "APP_NAME=myapp" not in capsys.readouterr().out
+
+    def test_audits_json(self, tmp_path, capsys) -> None:
+        content = json.dumps({"db": {"password": "hunter2"}})
+        code = main([_write(tmp_path, "a.json", content), "--audit"])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_FINDINGS
+        assert "password" in captured.out
+        assert "hunter2" not in captured.out
+
+
+class TestFormats:
+    """Format handling and auto-detection."""
+
+    def test_json_redaction_stays_valid_json(self, tmp_path, capsys) -> None:
+        content = json.dumps({"service": "api", "db": {"host": "localhost", "password": "hunter2"}})
+        main([_write(tmp_path, "app.json", content)])
+        out = capsys.readouterr().out
+
+        parsed = json.loads(out)
+        assert parsed["db"]["password"] == "[REDACTED]"
+        assert parsed["db"]["host"] == "localhost"
+
+    def test_ini_preserves_sections_and_separator(self, tmp_path, capsys) -> None:
+        content = "; note\n[database]\nhost = localhost\npassword : hunter2\n"
+        main([_write(tmp_path, "cfg.ini", content)])
+        out = capsys.readouterr().out
+
+        assert "; note" in out
+        assert "[database]" in out
+        assert "host = localhost" in out
+        assert "password : [REDACTED]" in out
+        assert "hunter2" not in out
+
+    def test_dsn_format(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "dsn.txt", "postgres://admin:s3cr3t@db:5432/prod\n"), "--format", "dsn"])
+        out = capsys.readouterr().out
+        assert out.strip() == "postgres://admin:[REDACTED]@db:5432/prod"
+
+    @pytest.mark.parametrize(
+        ("name", "content", "marker"),
+        [
+            ("app.json", '{"password": "hunter2"}', '"password": "[REDACTED]"'),
+            ("cfg.ini", "[s]\npassword = hunter2\n", "password = [REDACTED]"),
+            (".env", "DB_PASSWORD=hunter2\n", "DB_PASSWORD=[REDACTED]"),
+            ("plain.txt", "DB_PASSWORD=hunter2\n", "DB_PASSWORD=[REDACTED]"),
+        ],
+    )
+    def test_auto_detection(self, tmp_path, capsys, name: str, content: str, marker: str) -> None:
+        main([_write(tmp_path, name, content)])
+        out = capsys.readouterr().out
+        assert marker in out
+        assert "hunter2" not in out
+
+    def test_explicit_format_overrides_extension(self, tmp_path, capsys) -> None:
+        """A .json extension holding env content must not be parsed as JSON."""
+        code = main([_write(tmp_path, "mislabelled.json", "DB_PASSWORD=hunter2\n"), "--format", "env"])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_OK
+        assert "DB_PASSWORD=[REDACTED]" in out
+
+    def test_multiple_files(self, tmp_path, capsys) -> None:
+        first = _write(tmp_path, "one.env", "DB_PASSWORD=hunter2\n")
+        second = _write(tmp_path, "two.env", "API_TOKEN=s3cr3t\n")
+        code = main([first, second])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_OK
+        assert out.count("[REDACTED]") == 2
+
+
+class _FakeStdin:
+    """Minimal stdin stand-in for pipe tests."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text


### PR DESCRIPTION
Closes #2.

## Why a CLI at all

Checked prior art before writing anything ([full comparison in #2](https://github.com/featurecreep-cron/secretscreen/issues/2#issuecomment-5094058478)). gitleaks' `--redact` only redacts secrets inside its own findings output; TruffleHog has no redaction. The closest real overlap is [`msantos/redact`](https://codeberg.org/msantos/redact), so I installed it and ran it head-to-head on a realistic env file:

| | `msantos/redact` | secretscreen |
|---|---|---|
| `DB_PASSWORD=hunter2` | missed | redacted |
| `DATABASE_URL=postgres://admin:s3cr3t@…` | missed | `postgres://admin:[REDACTED]@…` |
| `AWS_SECRET_ACCESS_KEY=wJalr…` | missed | redacted |
| `GITHUB_TOKEN=ghp_…` | redacted | redacted |
| `SESSION_SECRET=correct-horse-…` | missed | redacted |

**1 of 5 vs 5 of 5.** Not a bug in `redact` — it's structural. Tools built on gitleaks rules are *value-format* detectors, and I confirmed against our own vendored copy that `hunter2`, `s3cr3t` and `correct-horse-battery-staple` match none of the 221 patterns. They can't; those values look like nothing. secretscreen catches them at layer 1 on the **key name**, which is the dominant case in a real `.env`.

For scanning a git repo, gitleaks remains the right tool. The README says so explicitly.

## Shape

One command, no subcommands — four public surfaces was too many for the job.

```
secretscreen [FILE...]              reads stdin when omitted or '-'
  --audit                           findings without values; exit 1 if any
  --format env|json|ini|dsn|auto    auto-detects from extension, then content
  --aggressive                      entropy layer
  --replacement TEXT
```

Redaction is structural, so comments, blank lines, quoting, `export` prefixes, INI sections and `:` separators survive the round trip. Using it is what caught the one real bug in development: the first version rebuilt the left-hand side of each line and turned `SPACED = value` into `SPACED= value`. It now echoes it verbatim.

## The property this is built around

The library's own docstring says *best-effort defense-in-depth, not a security boundary*. A cat-replacement is exactly the tool people stop thinking about, so the failure that matters isn't a false positive — it's **silently printing content that was never parsed**, which looks screened and isn't.

So: nothing unparsed reaches stdout verbatim. An unstructurable line is replaced with the redaction token, named on stderr, and exits 2. Values above the 1MB cap are reported as unscanned rather than passed off as clean — which is where the residual gap accepted in #18 becomes visible to the person who needs to see it.

| Exit | Meaning |
|---|---|
| 0 | parsed and screened |
| 1 | `--audit` found secrets |
| 2 | something unparsed or unreadable — see stderr |

## Also here

Two things nothing was enforcing, both now tested: pyproject's `version` and `__version__` agreeing (they'd silently drift and ship a wheel whose metadata contradicts the runtime value), and the console-script target staying importable.

## Verification

- 188 tests pass (160 + 26 CLI + 2 architecture); `ruff check`, `ruff format --check`, `mypy src/` clean
- Architecture tests constrain the new module too: stdlib-only, no logging, no broad `except`, `__all__` unchanged at six names
- Built the wheel and installed it into a clean **Python 3.11** env — `secretscreen` resolves on PATH and runs; `__version__` reports 0.2.0
- Every format and flag exercised by hand, not only via tests

Version bumped to 0.2.0. Publishing is gated on a GitHub release, so merging this doesn't push to PyPI on its own.