### PR TITLE
fix: lower detection size cap to 64KB — 1MB allowed a 107s scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Redaction is structural, not line-based: it parses the format, so it catches `DB
 | 1 | `--audit` found secrets |
 | 2 | Something could not be parsed or read — see stderr |
 
-That third case is the one that matters. This is best-effort defense-in-depth, and a cat-replacement is exactly the tool people stop thinking about, so the CLI never prints unparsed content verbatim: a line it cannot structure is replaced with the redaction token, named on stderr, and turns the exit code non-zero. The same applies to values above the 1 MB detection cap — they are reported as unscanned rather than passed off as clean.
+That third case is the one that matters. This is best-effort defense-in-depth, and a cat-replacement is exactly the tool people stop thinking about, so the CLI never prints unparsed content verbatim: a line it cannot structure is replaced with the redaction token, named on stderr, and turns the exit code non-zero. The same applies to values above the 64 KB detection cap — they are reported as unscanned rather than passed off as clean.
 
 If you are scanning a git repository rather than config-shaped data, use [gitleaks](https://github.com/gitleaks/gitleaks) instead. That is a different job.
 

--- a/docs/audits/security-audit-2026-04-05.md
+++ b/docs/audits/security-audit-2026-04-05.md
@@ -131,6 +131,29 @@ never touches the value — so `AWS_SECRET_ACCESS_KEY=<2MB blob>` passed through
 unredacted and `audit_pair` reported no finding. Trading a 7.7s CPU stall for a silent secret
 leak is the wrong direction for a redaction library.
 
+**Second correction (2026-07-27)**: the 1MB threshold was also wrong, and for the same
+reason the finding understated the problem — both were measured on benign input. The
+"~7.7s at 50MB" figure above reproduces (I measured 11.7s for 50MB of `"x"`), but a run of
+one character is not the worst case. On random high-entropy text — what a secret-shaped
+blob actually looks like — at least one vendored pattern backtracks and cost goes roughly
+quadratic above ~128KB:
+
+| size | `"x" * n` | random |
+|------|-----------|--------|
+| 64KB | — | 0.57s |
+| 128KB | — | 1.00s |
+| 256KB | — | 14s |
+| 1MB | 0.195s | **107s** |
+| 10MB | 1.8s | 20.7 min |
+
+A 1MB cap therefore admitted exactly the input that hurts most: a value one byte under it
+pinned a core for nearly two minutes. Lowered to 64KB (0.57s worst case), matching
+`MAX_PARSE_LENGTH`, which already bounded Layer 2 — so only Layers 3–5 narrow, and only
+for values large enough to be data dumps rather than config. Pinned by
+`test_worst_case_input_at_the_cap_stays_sub_second`.
+
+Not yet identified: *which* rule backtracks. Tracked with the gitleaks sync work in #1.
+
 The cap now gates Layers 2–5 only; Layer 1 always runs. Residual gap, accepted and tested
 (`test_oversized_value_under_non_denylisted_key_is_a_known_gap`): an oversized value under a key
 that Layer 1 does not match — including safe-suffix keys like `DATABASE_URL`, which depend on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "secretscreen"
-version = "0.2.0"
+version = "0.2.1"
 description = "Detect and redact secrets in key-value pairs, dicts, and environment variables."
 readme = "README.md"
 license = "MIT"

--- a/src/secretscreen/__init__.py
+++ b/src/secretscreen/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
     "redact_pair",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -173,14 +173,28 @@ def audit_dict(
 # Prevents stack overflow from crafted nested JSON/Python literals.
 _MAX_DETECT_DEPTH = 3
 
-# Maximum value length for the value-scanning layers (2-5). Values beyond this
-# are likely data dumps, not config values. Prevents DoS via large inputs hitting
-# 221+ regex patterns. Layer 1 (key-name match) is deliberately exempt: it reads
-# only the key, so an oversized value under a secret-named key is still redacted.
-# Residual gap: an oversized value under an innocuous key name is not scanned and
-# passes through unredacted. Callers that print values (e.g. a CLI) should surface
-# that skip rather than let it look screened.
-_MAX_DETECT_LENGTH = 1_048_576  # 1 MB
+# Maximum value length for the value-scanning layers (2-5). Prevents DoS via large
+# inputs hitting 221+ regex patterns, at least one of which backtracks badly.
+#
+# The threshold is set from measured worst-case input — random high-entropy text,
+# which is what a secret-shaped blob looks like — not from a run of one character.
+# Cost is roughly quadratic above ~128KB:
+#
+#     64KB   0.57s        256KB   14s
+#     128KB  1.00s        1MB    107s
+#
+# This was originally 1MB, chosen against a benign benchmark (a run of 'x', which
+# is ~500x faster at the same size). That admitted exactly the input that hurts:
+# a value one byte under the cap pinned a core for nearly two minutes. 64KB matches
+# MAX_PARSE_LENGTH in _parsers.py, which already bounded layer 2 — so this only
+# narrows layers 3-5, and only for values big enough to be data dumps, not config.
+#
+# Layer 1 (key-name match) is deliberately exempt: it reads only the key, so an
+# oversized value under a secret-named key is still redacted. Residual gap: an
+# oversized value under an innocuous key name is not scanned and passes through
+# unredacted. Callers that print values (e.g. a CLI) should surface that skip
+# rather than let it look screened.
+_MAX_DETECT_LENGTH = 65_536  # 64 KB
 
 
 def _detect(key: str, value: str, config: ScreenConfig, _depth: int = 0) -> Finding | None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 """Tests for core orchestration — redact_pair, redact_dict, audit_pair, audit_dict."""
 
 from secretscreen import Finding, Mode, audit_dict, audit_pair, redact_dict, redact_pair
+from secretscreen._core import _MAX_DETECT_LENGTH
 
 
 class TestRedactPair:
@@ -302,6 +303,35 @@ class TestSecurityFixes:
         finding = audit_pair("AWS_SECRET_ACCESS_KEY", "x" * 2_000_000)
         assert finding is not None
         assert finding.layer == "key_pattern"
+
+    def test_worst_case_input_at_the_cap_stays_sub_second(self) -> None:
+        """The cap must be set against adversarial input, not a run of one character.
+
+        At least one vendored gitleaks pattern backtracks: cost is roughly quadratic
+        above ~128KB on random high-entropy text (what a secret-shaped blob looks
+        like). The original 1MB cap allowed a ~107s scan. A run of 'x' is ~500x
+        faster at the same size, which is why it was not a safe benchmark.
+        """
+        import random
+        import time
+
+        random.seed(0)
+        alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/+="
+        at_cap = "".join(random.choices(alphabet, k=_MAX_DETECT_LENGTH))
+
+        start = time.perf_counter()
+        redact_pair("BLOB", at_cap)
+        elapsed = time.perf_counter() - start
+
+        # Measured ~0.57s at 64KB. 5s leaves headroom for slow CI without letting a
+        # future cap increase quietly reintroduce a multi-minute scan.
+        assert elapsed < 5.0, f"scan at the cap took {elapsed:.1f}s — is _MAX_DETECT_LENGTH too high?"
+
+    def test_cap_matches_the_parser_bound(self) -> None:
+        """Layer 2 was already bounded at 64KB; keeping both at one value is simpler."""
+        from secretscreen._parsers import MAX_PARSE_LENGTH
+
+        assert _MAX_DETECT_LENGTH == MAX_PARSE_LENGTH
 
     def test_large_value_layer_one_is_cheap(self) -> None:
         """Layer 1 on an oversized value must not fall through to the regex layers."""


### PR DESCRIPTION
Follow-up to #18. That PR fixed the size cap *failing open*; this one fixes the cap being **set to the wrong number**. Same root cause in both: the April audit's MEDIUM-3 was reasoned about using benign input.

## The measurement

A run of one character is not the worst case. On random high-entropy text — which is what a secret-shaped blob actually looks like — cost goes roughly quadratic above ~128KB:

| size | `"x" * n` | random |
|------|-----------|--------|
| 64KB | — | **0.57s** |
| 128KB | — | 1.00s |
| 256KB | — | 14s |
| 1MB | 0.195s | **107s** |
| 10MB | 1.8s | 20.7 min |

The audit's "~7.7s at 50MB" reproduces — I measured 11.7s for 50MB of `"x"` — but it is ~500x off for adversarial input at the same size. **A 1MB cap therefore admitted precisely the input that hurts most: a value one byte under it pinned a core for nearly two minutes.**

## Why 64KB

`MAX_PARSE_LENGTH` in `_parsers.py` already bounded layer 2 at 64KB. Matching it means only layers 3-5 narrow, and only for values large enough to be data dumps rather than config. Two caps at one value is also easier to reason about than two caps at two values.

Pinned by `test_worst_case_input_at_the_cap_stays_sub_second`, which scans random input *at* the cap and fails above 5s — so a future increase can't quietly reintroduce a multi-minute scan. Plus a test asserting the two caps stay equal.

## Which rule backtracks

Timed all 221 rules individually against 128KB of random text. Five account for ~56% of worst-case cost:

| rule | 128KB |
|---|---|
| `cisco-meraki-api-key` | 2.63s |
| `cohere-api-token` | 2.38s |
| `sumologic-access-id` | 2.04s |
| `okta-access-token` | 1.98s |
| `privateai-api-token` | 1.40s |

They share a shape — nested bounded lazy quantifiers over overlapping character classes:

```
[\w.-]{0,50}?(?i:[\w.-]{0,50}?(?:cohere|CO_API_KEY)...)
```

That's up to ~2,500 combinations per starting position, and Python's `re` has no memoization, so on non-matching text it backtracks at every offset. Go's RE2 (what gitleaks itself uses) has no backtracking at all — which is why these patterns are fine upstream and expensive here. **That's a portability hazard in the vendoring approach, not just a slow rule**, and it belongs with the sync work in #1. I'll note it there.

Worth stating plainly: all 221 rules run individually cost 18.8s on 128KB, but `matches_known_format` took ~1.0s on the same input, because the keyword pre-filter skips most rules. As input grows the odds of a keyword appearing by chance approach 1, so more rules run *and* each runs on a longer string. That compounding is part of the superlinearity.

## Scope

**Nobody is exploitable today.** Every current caller feeds it trusted input — roustabout reads the Docker daemon, the CLI reads local files. This matters for the use case the audit itself named: middleware or a log processor handling attacker-influenced values.

## Verification

- 190 tests pass; `ruff check`, `ruff format --check`, `mypy src/` clean
- Both corrections recorded in the audit doc, since that is the artifact the next reader will find
- README's "1 MB detection cap" updated to 64 KB

Version 0.2.1.