### PR TITLE
docs: document CLI installation via pipx and uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,20 @@ Best-effort defense-in-depth. Not a security boundary.
 
 ## Install
 
+As a library:
+
 ```
 pip install secretscreen
 ```
+
+As a command-line tool — `pipx` or `uv` keep it in its own environment and put `secretscreen` on your PATH everywhere, rather than only in whichever venv is active:
+
+```
+pipx install secretscreen
+uv tool install secretscreen
+```
+
+Zero dependencies, Python 3.11+.
 
 ## Quick start
 


### PR DESCRIPTION
The Install section predated the CLI and offered only `pip install secretscreen`, which puts the console script in whichever environment is active — fine for the library, wrong default for a tool you want on PATH.

Adds `pipx install` / `uv tool install`, and states the zero-dependency / 3.11+ constraint at the point of decision.

Note: I verified the plain-`pip` path from a clean venv on 0.2.0 and 0.2.1; neither pipx nor uv is installed on this machine, so those two lines are standard practice rather than something I ran.

Docs only — no version bump. Publishing is gated on a release, so PyPI's rendered README won't pick this up until the next one.