### PR TITLE
docs: reflect the CLI in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,15 @@ build-backend = "hatchling.build"
 [project]
 name = "secretscreen"
 version = "0.2.1"
-description = "Detect and redact secrets in key-value pairs, dicts, and environment variables."
+description = "Detect and redact secrets in key-value pairs, dicts, and environment variables. Library and CLI."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [{ name = "Cron", email = "cron@featurecreep.dev" }]
-keywords = ["secrets", "redaction", "security", "environment", "docker"]
+keywords = ["secrets", "redaction", "security", "environment", "docker", "cli", "command-line"]
 classifiers = [
     "Development Status :: 3 - Alpha",
+    "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -21,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Security",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Utilities",
     "Typing :: Typed",
 ]
 

--- a/src/secretscreen/__init__.py
+++ b/src/secretscreen/__init__.py
@@ -2,6 +2,9 @@
 
 Best-effort defense-in-depth. Not a security boundary.
 
+Also ships a CLI for shell use — `secretscreen FILE...` redacts and prints,
+`--audit` reports findings without values. See README.md.
+
 Five detection layers:
 1. Key-name denylist — substring match against known secret key patterns.
 2. Structured value parsing — JSON, Python literals, INI, DSN, URL query params.


### PR DESCRIPTION
Follow-up to #21. That fixed the README's install instructions; this fixes everything a user hits *before* the README.

Surveyed every doc surface. The README was the only one that knew a CLI existed:

| surface | was | now |
|---|---|---|
| `pyproject` description | library only | "Library and CLI." |
| keywords | no `cli` | + `cli`, `command-line` |
| classifiers | `Libraries :: Python Modules` | + `Environment :: Console`, `Topic :: Utilities` |
| `__init__` docstring | five detection layers | points at the CLI |
| GitHub description/topics | library only | updated (live already) |

`Environment :: Console` is the classifier PyPI filters on for command-line tools, so its absence made the package invisible to anyone browsing for one.

**Deliberately unchanged:** CONTRIBUTING.md. Its dev setup is generic — `pip install -e '.[dev]'`, pytest, ruff, mypy — and already covers `_cli.py` and `test_cli.py` without naming them. Adding CLI-specific prose there would be padding.

**Open question I did not decide:** SECURITY.md is a reporting policy with no threat model. It never states the "best-effort defense-in-depth, not a security boundary" caveat that the README and every module docstring lead with. That mattered less when the audience was Python callers reading the docstring; a CLI is easier to casually trust. I think it's worth a scope paragraph, but that's a judgment call about what the project promises, so I'd rather raise it than quietly write it.

190 tests pass; ruff and mypy clean. Metadata-only — no version bump, so this reaches PyPI whenever the next release goes out.