### PR TITLE
feat: --explain accounts for every value, including the untouched ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,33 @@ secretscreen [FILE...]              reads stdin when FILE is omitted or '-'
   --audit                           report findings without values; exit 1 if any
   --format env|json|ini|dsn|auto    default: auto-detect from extension, then content
   --aggressive                      add entropy detection; more false positives
+  --explain                         account on stderr for every value, including the untouched ones
   --replacement TEXT                default: [REDACTED]
 ```
 
-Redaction is structural, not line-based: it parses the format, so it catches `DB_PASSWORD=hunter2` on the key name and rewrites `postgres://admin:s3cr3t@host/db` to `postgres://admin:[REDACTED]@host/db` without destroying the rest of the line. Comments, blank lines, quoting, `export` prefixes, INI sections and `:` separators all survive the round trip.
+Redaction is structural, not line-based: it parses the format, so it catches `DB_PASSWORD=hunter2` on the key name and rewrites `postgres://admin:s3cr3t@host/db` to `postgres://admin:REDACTED@host/db` without destroying the rest of the line. Comments, blank lines, quoting, `export` prefixes, INI sections and `:` separators all survive the round trip.
+
+Inside a URL the replacement drops its brackets, because `[` in that position makes the result unparseable — screening already-screened output would otherwise destroy it.
+
+### Knowing what was left alone
+
+A missed secret is invisible: the output looks screened and nothing says otherwise. `--explain` writes an account of every value to **stderr**, so stdout stays a usable redacted stream and `secretscreen app.env --explain > clean.env` still works.
+
+```
+$ secretscreen watchtower.env --explain > screened.env
+secretscreen: explain — key names and reasons only, no values
+  redacted   WATCHTOWER_NOTIFICATION_URL  url_credentials  credential in userinfo position
+  vetoed     GF_OAUTH_TOKEN_URL           key_pattern      matched 'token', suppressed by safe suffix '_url'
+  clean      IMAGE_DIGEST                 -                entropy 4.14 (aggressive would not flag; threshold 4.50)
+  clean      DEPLOY_PUBLIC_KEY            -                entropy 4.67 (aggressive WOULD flag; threshold 4.50)
+  unscanned  BACKUP_BLOB                  -                2202009 bytes exceeds the 65536-byte scan cap
+```
+
+Four states. `redacted` and `clean` are self-explanatory; the two in between are the ones worth reading. **`vetoed`** means a rule fired and something suppressed it — that is where the tool decided to stay quiet. **`unscanned`** means the size cap skipped the value-scanning layers.
+
+Clean lines carry the nearest miss rather than silence. The entropy figure is computed even in normal mode, where that layer never runs, so you can see what `--aggressive` would change before turning it on.
+
+Like `--audit`, this never prints a value — paste it into a bug report as-is.
 
 **What the exit code means:**
 

--- a/src/secretscreen/_cli.py
+++ b/src/secretscreen/_cli.py
@@ -26,6 +26,8 @@ from secretscreen._core import (
     Mode,
     audit_dict,
     audit_pair,
+    explain_dict,
+    explain_pair,
     redact_dict,
     redact_pair,
 )
@@ -33,7 +35,7 @@ from secretscreen._core import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from secretscreen._core import Finding
+    from secretscreen._core import Explanation, Finding
 
 EXIT_OK = 0
 EXIT_FINDINGS = 1
@@ -44,6 +46,11 @@ FORMATS = ("env", "json", "ini", "dsn", "auto")
 _JSON_EXTENSIONS = {".json"}
 _INI_EXTENSIONS = {".ini", ".cfg", ".conf", ".properties"}
 _ENV_EXTENSIONS = {".env", ".envrc"}
+
+# Column widths for --explain output. The key column is capped so one very long
+# key (a grep prefix, a deep JSON path) cannot push every reason off the screen.
+_EXPLAIN_KEY_MAX_WIDTH = 44
+_EXPLAIN_LAYER_WIDTH = 17
 
 # Separator characters by format, in precedence order.
 _SEPARATORS = {"env": ("=",), "ini": ("=", ":")}
@@ -60,6 +67,7 @@ class _Report:
     def __init__(self) -> None:
         self.findings: list[tuple[str, int, Finding]] = []
         self.problems: list[str] = []
+        self.explanations: list[tuple[str, int, Explanation]] = []
 
     def problem(self, source: str, lineno: int, message: str) -> None:
         self.problems.append(f"{source}:{lineno}: {message}")
@@ -139,6 +147,9 @@ def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, r
         quote, inner = _strip_quotes(value.strip())
         leading = value[: len(value) - len(value.lstrip())]
 
+        if args.explain:
+            report.explanations.append((source, lineno, explain_pair(key, inner, mode=args.mode)))
+
         if args.audit:
             finding = audit_pair(key, inner, mode=args.mode)
             if finding is not None:
@@ -163,6 +174,10 @@ def _process_json(text: str, source: str, args: argparse.Namespace, report: _Rep
         report.problem(source, exc.lineno, f"invalid JSON ({exc.msg}); nothing printed")
         return []
 
+    if args.explain:
+        for explanation in explain_dict(data, mode=args.mode):
+            report.explanations.append((source, 0, explanation))
+
     if args.audit:
         for finding in audit_dict(data, mode=args.mode):
             report.findings.append((source, 0, finding))
@@ -179,6 +194,8 @@ def _process_dsn(text: str, source: str, args: argparse.Namespace, report: _Repo
         if not raw.strip():
             out.append(raw)
             continue
+        if args.explain:
+            report.explanations.append((source, lineno, explain_pair("dsn", raw.strip(), mode=args.mode)))
         if args.audit:
             finding = audit_pair("dsn", raw.strip(), mode=args.mode)
             if finding is not None:
@@ -203,6 +220,35 @@ def _read(path: str, report: _Report) -> str | None:
         return None
 
 
+def _print_explanations(report: _Report) -> None:
+    """Write the accounting to stderr so stdout stays a usable redacted stream.
+
+    Location is shown only when more than one input contributed, so the common
+    single-file case stays readable.
+    """
+    if not report.explanations:
+        return
+
+    print("secretscreen: explain — key names and reasons only, no values", file=sys.stderr)
+
+    sources = {source for source, _, _ in report.explanations}
+    show_location = len(sources) > 1
+    labels = [
+        f"{source}:{lineno}" if show_location and lineno else source if show_location else ""
+        for source, lineno, _ in report.explanations
+    ]
+
+    state_width = max(len(e.state) for _, _, e in report.explanations)
+    key_width = min(max(len(e.key) for _, _, e in report.explanations), _EXPLAIN_KEY_MAX_WIDTH)
+    label_width = max((len(label) for label in labels), default=0)
+
+    for label, (_, _, explanation) in zip(labels, report.explanations, strict=True):
+        prefix = f"{label:<{label_width}}  " if show_location else ""
+        layer = explanation.layer or "-"
+        columns = f"{explanation.state:<{state_width}}  {explanation.key:<{key_width}}  {layer:<{_EXPLAIN_LAYER_WIDTH}}"
+        print(f"  {prefix}{columns}  {explanation.reason}", file=sys.stderr)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="secretscreen",
@@ -214,6 +260,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--audit", action="store_true", help="report findings without values; exit 1 if any are found")
     parser.add_argument("--format", choices=FORMATS, default="auto", help="input format (default: auto-detect)")
     parser.add_argument("--aggressive", action="store_true", help="add entropy detection; more false positives")
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="report on stderr what happened to every value and why, including the ones left alone",
+    )
     parser.add_argument("--replacement", default=REDACTED, help=f"replacement text (default: {REDACTED})")
     return parser
 
@@ -250,6 +301,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         for line in lines:
             print(line)
+
+    _print_explanations(report)
 
     for problem in report.problems:
         print(f"secretscreen: {problem}", file=sys.stderr)

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass
 
-from secretscreen._entropy import looks_like_secret
+from secretscreen._entropy import MIN_ENTROPY_LENGTH, looks_like_secret, shannon_entropy
 from secretscreen._formats import matches_known_format
 from secretscreen._keys import (
     DEFAULT_KEY_PATTERNS,
@@ -16,7 +16,7 @@ from secretscreen._keys import (
     matches_key_pattern,
 )
 from secretscreen._parsers import extract_pairs
-from secretscreen._urls import has_url_credentials, redact_url_credentials
+from secretscreen._urls import credential_position, has_url_credentials, redact_url_credentials
 
 REDACTED = "[REDACTED]"
 
@@ -390,6 +390,177 @@ def _redact_recursive(
         return [_redact_recursive(item, config, _depth + 1) for item in data]
 
     return data
+
+
+# Explanation states. A value is either redacted, deliberately not redacted,
+# not scanned, or nothing matched it — and the middle two are the ones worth
+# reading, because they are where the tool made a decision to stay quiet.
+STATE_REDACTED = "redacted"
+STATE_VETOED = "vetoed"
+STATE_CLEAN = "clean"
+STATE_UNSCANNED = "unscanned"
+
+
+@dataclass(frozen=True, slots=True)
+class Explanation:
+    """Why one key-value pair was or was not redacted. Never holds the value."""
+
+    key: str
+    state: str
+    layer: str
+    reason: str
+
+
+def _vetoed_by_safe_suffix(key: str, config: ScreenConfig) -> tuple[str, str] | None:
+    """Return (pattern, suffix) when a safe suffix suppressed a layer-1 match."""
+    matched = matches_key_pattern(key, config.patterns, safe_suffixes=())
+    if matched is None:
+        return None
+    key_lower = key.lower()
+    for suffix in config.safe_suffixes:
+        if key_lower.endswith(suffix):
+            return matched, suffix
+    return None
+
+
+def _describe_finding(finding: Finding, value: str) -> str:
+    """Render a finding as a reason phrase, without quoting the value."""
+    detail = finding.reason.partition(":")[2]
+    if finding.layer == "key_pattern":
+        return f"matched {detail!r}"
+    if finding.layer == "url_credentials":
+        position = credential_position(value)
+        return f"credential in {position} position" if position else "URL with embedded credentials"
+    if finding.layer == "format_detection":
+        return f"matches known format {detail}"
+    if finding.layer == "entropy":
+        return f"entropy {detail}"
+    if finding.layer == "structured_parsing":
+        return finding.detail or finding.reason
+    return finding.reason
+
+
+def _clean_reason(value: str, config: ScreenConfig) -> str:
+    """Explain why nothing matched, quoting the nearest miss rather than silence.
+
+    The entropy figure is computed even in normal mode, where layer 5 never
+    runs. It is a single pass over the value and it is the one number that says
+    what --aggressive would do differently, so the mode choice can be measured
+    instead of guessed.
+    """
+    chars = "".join(value.split())
+    if len(chars) < MIN_ENTROPY_LENGTH:
+        return f"{len(chars)} chars, below the {MIN_ENTROPY_LENGTH}-char entropy floor"
+
+    entropy = shannon_entropy(value, _stripped=chars)
+    threshold = config.entropy_threshold
+    if config.mode == Mode.NORMAL:
+        verdict = "aggressive WOULD flag" if entropy >= threshold else "aggressive would not flag"
+        return f"entropy {entropy:.2f} ({verdict}; threshold {threshold:.2f})"
+    return f"entropy {entropy:.2f}, below threshold {threshold:.2f}"
+
+
+def explain_pair(
+    key: str,
+    value: str,
+    *,
+    mode: Mode = Mode.NORMAL,
+    extra_keys: tuple[str, ...] = (),
+    safe_suffixes: tuple[str, ...] = DEFAULT_SAFE_SUFFIXES,
+    entropy_threshold: float = 4.5,
+) -> Explanation:
+    """Account for one pair: what happened to it, and why.
+
+    Reports on values that were *not* redacted as well as values that were.
+    An undetected secret is invisible by definition, so the only defence
+    against one is making the non-detections reviewable.
+    """
+    config = ScreenConfig(
+        mode=mode,
+        extra_keys=extra_keys,
+        safe_suffixes=safe_suffixes,
+        entropy_threshold=entropy_threshold,
+    )
+    return _explain(key, value, config)
+
+
+def _explain(key: str, value: str, config: ScreenConfig) -> Explanation:
+    if not isinstance(value, str) or not value:
+        return Explanation(key, STATE_CLEAN, "", "empty value")
+
+    finding = _detect(key, value, config)
+    if finding is not None:
+        return Explanation(key, STATE_REDACTED, finding.layer, _describe_finding(finding, value))
+
+    # Order matters: layer 1 still redacts an oversized value under a secret
+    # key name, so the size skip is only reported once detection has declined.
+    if len(value) > _MAX_DETECT_LENGTH:
+        return Explanation(
+            key,
+            STATE_UNSCANNED,
+            "",
+            f"{len(value)} bytes exceeds the {_MAX_DETECT_LENGTH}-byte scan cap",
+        )
+
+    vetoed = _vetoed_by_safe_suffix(key, config)
+    if vetoed is not None:
+        pattern, suffix = vetoed
+        return Explanation(
+            key,
+            STATE_VETOED,
+            "key_pattern",
+            f"matched {pattern!r}, suppressed by safe suffix {suffix!r}",
+        )
+
+    return Explanation(key, STATE_CLEAN, "", _clean_reason(value, config))
+
+
+def explain_dict(
+    data: dict[str, object] | list[object] | object,
+    *,
+    mode: Mode = Mode.NORMAL,
+    extra_keys: tuple[str, ...] = (),
+    safe_suffixes: tuple[str, ...] = DEFAULT_SAFE_SUFFIXES,
+    entropy_threshold: float = 4.5,
+) -> list[Explanation]:
+    """Account for every string value in a nested structure."""
+    config = ScreenConfig(
+        mode=mode,
+        extra_keys=extra_keys,
+        safe_suffixes=safe_suffixes,
+        entropy_threshold=entropy_threshold,
+    )
+    explanations: list[Explanation] = []
+    _explain_recursive(data, config, explanations)
+    return explanations
+
+
+def _explain_recursive(
+    data: object,
+    config: ScreenConfig,
+    explanations: list[Explanation],
+    _depth: int = 0,
+    _prefix: str = "",
+) -> None:
+    """Walk a structure, accounting for every string value it contains."""
+    if _depth >= _MAX_RECURSIVE_DEPTH:
+        return
+
+    if isinstance(data, dict):
+        for k, v in data.items():
+            key_str = f"{_prefix}.{k}" if _prefix else str(k)
+            if isinstance(v, str):
+                explanations.append(_explain(key_str, v, config))
+            elif isinstance(v, (dict, list)):
+                _explain_recursive(v, config, explanations, _depth + 1, key_str)
+
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            key_str = f"{_prefix}[{i}]"
+            if isinstance(item, str):
+                explanations.append(_explain(key_str, item, config))
+            elif isinstance(item, (dict, list)):
+                _explain_recursive(item, config, explanations, _depth + 1, key_str)
 
 
 def _audit_recursive(

--- a/src/secretscreen/_urls.py
+++ b/src/secretscreen/_urls.py
@@ -124,6 +124,20 @@ def has_url_credentials(value: str) -> bool:
         return True
 
 
+def credential_position(value: str) -> str | None:
+    """Name where the credential sits, for diagnostics. None if there is none.
+
+    Returns "userinfo" or "password". An unparseable URL-shaped value reports
+    "unparseable", matching has_url_credentials, which treats it as a credential.
+    """
+    if "://" not in value:
+        return None
+    try:
+        return _credential_kind(urlsplit(_strip_url_wrapper(value)))
+    except (ValueError, AttributeError):
+        return "unparseable"
+
+
 def redact_url_credentials(value: str, replacement: str = _DEFAULT_REPLACEMENT) -> str:
     """Replace only the credential portion of a URL.
 

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,255 @@
+"""Tests for --explain, the accounting of what was left alone and why.
+
+An undetected secret is invisible by definition: the output looks screened and
+nothing signals otherwise. The only defence is making the non-detections
+reviewable, so most of these tests are about the values that were *not*
+redacted — and about the guarantee that reporting on them never quotes them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from secretscreen._cli import EXIT_FINDINGS, EXIT_OK, main
+from secretscreen._core import (
+    STATE_CLEAN,
+    STATE_REDACTED,
+    STATE_UNSCANNED,
+    STATE_VETOED,
+    Mode,
+    explain_dict,
+    explain_pair,
+)
+
+SENTINEL = "zQ7pLmXv3TdNhRkWbFgY9sJc2AeUoI4t"
+
+
+def _write(tmp_path, name: str, content: str) -> str:
+    path = tmp_path / name
+    path.write_text(content)
+    return str(path)
+
+
+class TestRedactedState:
+    """A value a layer fired on, and which layer it was."""
+
+    @pytest.mark.parametrize(
+        ("key", "value", "layer", "reason_fragment"),
+        [
+            ("DB_PASSWORD", "hunter2", "key_pattern", "matched 'password'"),
+            ("AUTH", "postgres://admin:pw@db.lan/app", "url_credentials", "password position"),
+            ("NOTIFY", "discord://tokenvalue@1234567890", "url_credentials", "userinfo position"),
+            ("BLOB", '{"api_key": "abc123def456"}', "structured_parsing", "api_key"),
+        ],
+    )
+    def test_layer_and_reason(self, key: str, value: str, layer: str, reason_fragment: str) -> None:
+        explanation = explain_pair(key, value)
+        assert explanation.state == STATE_REDACTED
+        assert explanation.layer == layer
+        assert reason_fragment in explanation.reason
+
+    def test_entropy_layer_reports_the_score(self) -> None:
+        explanation = explain_pair("BLOB", SENTINEL, mode=Mode.AGGRESSIVE)
+        assert explanation.state == STATE_REDACTED
+        assert explanation.layer == "entropy"
+        assert "entropy" in explanation.reason
+
+
+class TestVetoedState:
+    """A layer would have fired and a rule suppressed it.
+
+    This is the state worth reading — it is where the tool decided to stay
+    quiet, as opposed to nothing matching at all.
+    """
+
+    @pytest.mark.parametrize(
+        ("key", "suffix"),
+        [
+            ("GF_OAUTH_TOKEN_URL", "_url"),
+            ("PASSWORD_FILE", "password_file"),
+            ("SESSION_KEY_PREFIX", "session_key_prefix"),
+        ],
+    )
+    def test_safe_suffix_veto_is_reported(self, key: str, suffix: str) -> None:
+        explanation = explain_pair(key, "https://auth.example.com/o/token/")
+        assert explanation.state == STATE_VETOED
+        assert explanation.layer == "key_pattern"
+        assert suffix in explanation.reason
+
+    def test_veto_is_not_reported_when_a_later_layer_catches_it(self) -> None:
+        """A vetoed layer-1 match still redacts if layer 4 fires — that is not a veto."""
+        explanation = explain_pair("NOTIFY_TOKEN_URL", "discord://tokenvalue@123")
+        assert explanation.state == STATE_REDACTED
+        assert explanation.layer == "url_credentials"
+
+    def test_key_matching_no_pattern_is_clean_not_vetoed(self) -> None:
+        assert explain_pair("SMTP_HOST", "smtp.fastmail.com").state == STATE_CLEAN
+
+
+class TestUnscannedState:
+    """The size cap skipped the value-scanning layers."""
+
+    def test_oversized_value_under_innocuous_key(self) -> None:
+        explanation = explain_pair("PAYLOAD", "x" * 70_000)
+        assert explanation.state == STATE_UNSCANNED
+        assert "scan cap" in explanation.reason
+
+    def test_oversized_value_under_secret_key_is_redacted_not_unscanned(self) -> None:
+        """Layer 1 reads the key, not the value, so the cap never applies to it."""
+        explanation = explain_pair("AWS_SECRET_ACCESS_KEY", "x" * 70_000)
+        assert explanation.state == STATE_REDACTED
+        assert explanation.layer == "key_pattern"
+
+
+class TestCleanState:
+    """Nothing matched — with the nearest miss, not just silence."""
+
+    def test_below_entropy_floor_reports_length(self) -> None:
+        explanation = explain_pair("TZ", "America/Los_Angeles")
+        assert explanation.state == STATE_CLEAN
+        assert "below the 20-char entropy floor" in explanation.reason
+
+    def test_reports_entropy_and_what_aggressive_would_do(self) -> None:
+        """The number is the point: it makes the mode choice measurable."""
+        low = explain_pair("IMAGE_DIGEST", "sha256:" + "a1b2c3d4e5f6" * 5)
+        assert "aggressive would not flag" in low.reason
+
+        high = explain_pair("DEPLOY_PUBLIC_KEY", f"ssh-rsa AAAAB3Nza{SENTINEL}")
+        assert "aggressive WOULD flag" in high.reason
+
+    def test_aggressive_mode_omits_the_counterfactual(self) -> None:
+        explanation = explain_pair("PATH_LIST", "/mnt/user/appdata:/mnt/user/documents", mode=Mode.AGGRESSIVE)
+        assert "below threshold" in explanation.reason
+        assert "aggressive" not in explanation.reason
+
+    def test_empty_value(self) -> None:
+        assert explain_pair("EMPTY", "").state == STATE_CLEAN
+
+    def test_entropy_threshold_is_honoured(self) -> None:
+        assert explain_pair("BLOB", SENTINEL, entropy_threshold=9.0).state == STATE_CLEAN
+        assert explain_pair("BLOB", SENTINEL, mode=Mode.AGGRESSIVE, entropy_threshold=9.0).state == STATE_CLEAN
+
+
+class TestNeverQuotesTheValue:
+    """The guarantee that makes explain output safe to paste into an issue."""
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("DB_PASSWORD", SENTINEL),
+            ("NOTIFY", f"discord://{SENTINEL}@1234567890"),
+            ("AUTH", f"postgres://admin:{SENTINEL}@db.lan/app"),
+            ("BLOB", '{"api_key": "' + SENTINEL + '"}'),
+            ("PLAIN", SENTINEL),
+            ("GF_OAUTH_TOKEN_URL", SENTINEL),
+            ("PAYLOAD", SENTINEL * 3000),
+        ],
+    )
+    @pytest.mark.parametrize("mode", [Mode.NORMAL, Mode.AGGRESSIVE])
+    def test_value_never_appears_in_any_field(self, key: str, value: str, mode: Mode) -> None:
+        explanation = explain_pair(key, value, mode=mode)
+        rendered = f"{explanation.key} {explanation.state} {explanation.layer} {explanation.reason}"
+        assert SENTINEL not in rendered
+
+
+class TestExplainDict:
+    """Structured input is accounted for the same way, with path-style keys."""
+
+    def test_nested_keys_and_list_indices(self) -> None:
+        data = {"db": {"password": "hunter2", "host": "db.lan"}, "tags": ["prod", "eu-west"]}
+        by_key = {e.key: e for e in explain_dict(data)}
+
+        assert by_key["db.password"].state == STATE_REDACTED
+        assert by_key["db.host"].state == STATE_CLEAN
+        assert by_key["tags[0]"].state == STATE_CLEAN
+        assert by_key["tags[1]"].state == STATE_CLEAN
+
+    def test_every_string_value_is_accounted_for(self) -> None:
+        """The point of the feature: no value is silently omitted."""
+        data = {"a": "one", "b": {"c": "two", "d": ["three", "four"]}}
+        assert len(explain_dict(data)) == 4
+
+    def test_structures_nested_inside_lists(self) -> None:
+        data = {"services": [{"env": {"DB_PASSWORD": "hunter2"}}, ["nested", {"API_TOKEN": "abc"}]]}
+        by_key = {e.key: e for e in explain_dict(data)}
+
+        assert by_key["services[0].env.DB_PASSWORD"].state == STATE_REDACTED
+        assert by_key["services[1][0]"].state == STATE_CLEAN
+        assert by_key["services[1][1].API_TOKEN"].state == STATE_REDACTED
+
+    def test_non_string_values_are_skipped(self) -> None:
+        assert [e.key for e in explain_dict({"n": 1, "b": True, "s": "text", "z": None})] == ["s"]
+
+    def test_deep_nesting_terminates(self) -> None:
+        data: dict[str, object] = {"leaf": "value"}
+        for _ in range(150):
+            data = {"nest": data}
+        explain_dict(data)  # must not raise
+
+
+class TestExplainCli:
+    """Stream separation, composition with --audit, and exit codes."""
+
+    ENV = "DB_PASSWORD=hunter2\nLOG_LEVEL=debug\nGF_OAUTH_TOKEN_URL=https://auth.example.com/o/token/\n"
+
+    def test_goes_to_stderr_not_stdout(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "a.env", self.ENV), "--explain"])
+        captured = capsys.readouterr()
+
+        assert "explain" in captured.err
+        assert "redacted" in captured.err
+        assert "explain" not in captured.out
+
+    def test_stdout_is_byte_identical_with_and_without_explain(self, tmp_path, capsys) -> None:
+        """stdout has to stay a usable redacted stream when explain is on."""
+        path = _write(tmp_path, "a.env", self.ENV)
+        main([path])
+        plain = capsys.readouterr().out
+        main([path, "--explain"])
+        assert capsys.readouterr().out == plain
+
+    def test_exit_code_is_unchanged(self, tmp_path, capsys) -> None:
+        path = _write(tmp_path, "a.env", self.ENV)
+        assert main([path, "--explain"]) == EXIT_OK
+        capsys.readouterr()
+        assert main([path, "--audit", "--explain"]) == EXIT_FINDINGS
+
+    def test_composes_with_audit(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "a.env", self.ENV), "--audit", "--explain"])
+        captured = capsys.readouterr()
+
+        assert "DB_PASSWORD" in captured.out  # audit findings on stdout
+        assert "LOG_LEVEL" in captured.err  # the complement on stderr
+        assert "vetoed" in captured.err
+
+    def test_never_prints_values(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "a.env", f"DB_PASSWORD={SENTINEL}\nPLAIN={SENTINEL}\n"), "--audit", "--explain"])
+        captured = capsys.readouterr()
+        assert SENTINEL not in captured.err
+        assert SENTINEL not in captured.out
+
+    def test_location_shown_only_for_multiple_inputs(self, tmp_path, capsys) -> None:
+        one = _write(tmp_path, "a.env", self.ENV)
+        two = _write(tmp_path, "b.env", "API_TOKEN=abc\n")
+
+        main([one, "--explain"])
+        assert "a.env:1" not in capsys.readouterr().err
+
+        main([one, two, "--explain"])
+        assert "a.env:1" in capsys.readouterr().err
+
+    def test_no_header_when_nothing_to_report(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "empty.env", "# just a comment\n"), "--explain"])
+        assert "explain" not in capsys.readouterr().err
+
+    def test_absent_by_default(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "a.env", self.ENV)])
+        assert "explain" not in capsys.readouterr().err
+
+    def test_dsn_format(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "d.txt", "postgres://admin:pw@db:5432/prod\n"), "--format", "dsn", "--explain"])
+        assert "url_credentials" in capsys.readouterr().err
+
+    def test_json_format_uses_path_keys(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "c.json", '{"db": {"password": "hunter2"}}'), "--explain"])
+        assert "db.password" in capsys.readouterr().err

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -224,6 +224,40 @@ class TestUrlRedactionEdgeCases:
         assert "s3cr3t" not in redact_pair("NOTIFY", value)
 
 
+class TestCredentialPosition:
+    """Names where the credential sits, for --explain. Never returns the value."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("postgres://admin:pw@db.lan/app", "password"),
+            ("discord://tokenvalue@1234567890", "userinfo"),
+            ("https://user@github.com/repo", None),
+            ("https://example.com", None),
+            ("not a url", None),
+            ("/var/lib/data", None),
+            ("http://[user:pw@host", "unparseable"),
+        ],
+    )
+    def test_position(self, value: str, expected: str | None) -> None:
+        from secretscreen._urls import credential_position
+
+        assert credential_position(value) == expected
+
+    def test_agrees_with_has_url_credentials(self) -> None:
+        """A position must be reported exactly when a credential is detected."""
+        from secretscreen._urls import credential_position
+
+        for value in [
+            "postgres://admin:pw@db.lan/app",
+            "discord://tokenvalue@123",
+            "https://user@github.com/repo",
+            "https://example.com",
+            "http://[user:pw@host",
+        ]:
+            assert (credential_position(value) is not None) is has_url_credentials(value)
+
+
 class TestNetlocReplacementToken:
     """The replacement token is stripped of URL-structural characters.
 


### PR DESCRIPTION
## Why

A missed secret is invisible by construction — the output looks screened and nothing says otherwise. The v0.3.0 userinfo leak surfaced only because someone asked what a particular command would print. That is not a process that scales.

`--explain` makes the non-detections reviewable. Config can fix repeated *false positives*; nothing fixes repeated false negatives except making them visible.

## What it looks like

```
$ secretscreen watchtower.env --explain > screened.env
secretscreen: explain — key names and reasons only, no values
  redacted   WATCHTOWER_NOTIFICATION_URL  url_credentials  credential in userinfo position
  vetoed     GF_OAUTH_TOKEN_URL           key_pattern      matched 'token', suppressed by safe suffix '_url'
  clean      IMAGE_DIGEST                 -                entropy 4.14 (aggressive would not flag; threshold 4.50)
  clean      DEPLOY_PUBLIC_KEY            -                entropy 4.67 (aggressive WOULD flag; threshold 4.50)
  unscanned  BACKUP_BLOB                  -                2202009 bytes exceeds the 65536-byte scan cap
```

## Design

**Four states, not two.** `redacted` and `clean` are obvious. The two in between carry the signal:

- **`vetoed`** — a layer fired and a rule suppressed it, and nothing downstream caught it. This is where the tool *decided* to stay quiet. Today that means a safe suffix; once `show` rules exist it is how you find one that has silently gone stale and is now hiding a real secret.
- **`unscanned`** — the 64 KB cap skipped the value-scanning layers.

**stderr, always.** stdout stays a usable redacted stream, so `secretscreen app.env --explain > clean.env` still produces the file. Exit codes are untouched — diagnostic output only. Composes with `--audit`, which puts findings on stdout while `--explain` puts the complement on stderr.

**Clean lines carry the nearest miss.** A bare "clean" is 22 lines of noise on a 32-line file. `entropy 4.43, threshold 4.50` is what showed the threshold was mistuned in the first place. Entropy is computed even in `normal` mode, where layer 5 never runs — a single pass, and the one number that says what `--aggressive` would do differently, so the mode choice becomes measurable instead of a guess.

**Never prints a value.** Same guarantee as `--audit` and for the same reason: this is the output you would paste into an issue asking why something was not caught. Pinned by a test that runs a sentinel through every state and both modes.

## Scope

Implemented in `_core`, not exported — `__all__` is fixed at six names by an architecture test and `_cli` is the only consumer, so there is no public API change. Adds `credential_position()` to `_urls` so the URL reason can name whether the secret sat in the userinfo or the password.

Also corrects the README, which still showed the pre-0.3.0 bracketed token in URL output.

## Tests

240 → 294. `_urls.py` reaches 100% line coverage; overall 95%.

Covers each layer's state and reason, the veto path *and* the case where a later layer catches a vetoed match (not a veto), oversized values under both matching and non-matching keys, the entropy floor and threshold wording in both modes, structured input with dotted and indexed key paths including structures nested inside lists, stream separation, byte-identical stdout with and without the flag, exit-code stability, composition with `--audit`, location shown only for multiple inputs, and the no-values guarantee at both the core and CLI level.