### PR TITLE
feat: yaml-shaped input and grep line prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ secretscreen --audit config.json            # findings only, no values, exit 1 i
 ```
 secretscreen [FILE...]              reads stdin when FILE is omitted or '-'
   --audit                           report findings without values; exit 1 if any
-  --format env|json|ini|dsn|auto    default: auto-detect from extension, then content
+  --format env|json|ini|yaml|dsn|auto  default: auto-detect from extension, then content
   --aggressive                      add entropy detection; more false positives
   --explain                         account on stderr for every value, including the untouched ones
   --replacement TEXT                default: [REDACTED]
@@ -75,6 +75,37 @@ secretscreen [FILE...]              reads stdin when FILE is omitted or '-'
 Redaction is structural, not line-based: it parses the format, so it catches `DB_PASSWORD=hunter2` on the key name and rewrites `postgres://admin:s3cr3t@host/db` to `postgres://admin:REDACTED@host/db` without destroying the rest of the line. Comments, blank lines, quoting, `export` prefixes, INI sections and `:` separators all survive the round trip.
 
 Inside a URL the replacement drops its brackets, because `[` in that position makes the result unparseable — screening already-screened output would otherwise destroy it.
+
+### Compose files and grep output
+
+```
+$ secretscreen compose.yaml
+# Watchtower stack
+services:
+  watchtower:
+    image: containrrr/watchtower
+    environment:
+      WATCHTOWER_NOTIFICATION_URL: discord://REDACTED@1234567890
+      WATCHTOWER_CLEANUP: "true"
+    # keep an eye on this one
+    restart: unless-stopped
+```
+
+Indentation, comments, and block openers (`services:`) survive; only values are touched. List entries are screened whether they carry a key (`- DB_PASSWORD=hunter2`) or not (`- discord://token@id`).
+
+This is **line-oriented, not a real YAML parse** — a parser would mean a third-party dependency, and this package is stdlib-only on purpose. Block scalars (`|`, `>`) are the visible consequence: their bodies are not `key: value`, so they are redacted and reported rather than quietly passed through.
+
+grep's `file:NN:` and `file-NN-` markers are recognised and stripped before parsing, then put back on output, so `grep -rn SECRET ~/stacks | secretscreen` keeps its file-and-line context:
+
+```
+$ grep -n 'NOTIFICATION' compose.yaml | secretscreen
+secretscreen: detected grep-style line prefixes; stripped before parsing, restored on output
+6:      WATCHTOWER_NOTIFICATION_URL: discord://REDACTED@1234567890
+```
+
+That stripping is what makes colon-separated detection safe to attempt at all. Without it the first colon on the line belongs to grep's line number, the key becomes `6`, and the whole remainder — secret included — becomes one value that matches nothing. So when the input is only partly prefixed and the shape is ambiguous, the sniffer refuses the colon format and falls back to `env`, which redacts what it cannot parse. Useless output beats quiet output.
+
+One case stays deliberately blunt: a single stream mixing formats, such as `grep -rn` across both `.env` and `.yaml` files, picks the majority format and redacts the rest wholesale. Loud and safe rather than half-parsed.
 
 ### Knowing what was left alone
 

--- a/src/secretscreen/_cli.py
+++ b/src/secretscreen/_cli.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from typing import TYPE_CHECKING
 
@@ -41,11 +42,36 @@ EXIT_OK = 0
 EXIT_FINDINGS = 1
 EXIT_ERROR = 2
 
-FORMATS = ("env", "json", "ini", "dsn", "auto")
+FORMATS = ("env", "json", "ini", "yaml", "dsn", "auto")
 
 _JSON_EXTENSIONS = {".json"}
 _INI_EXTENSIONS = {".ini", ".cfg", ".conf", ".properties"}
 _ENV_EXTENSIONS = {".env", ".envrc"}
+_YAML_EXTENSIONS = {".yaml", ".yml"}
+
+# grep prefixes its output with `file:` and `line:` when given -n or several
+# files. Those colons break any colon-separated format: the first ':' belongs
+# to the prefix, so the key becomes a line number and the rest of the line —
+# including any secret — becomes one opaque value that no layer matches.
+#
+# Detection is document-wide rather than per-line. A single line starting with
+# digits and a colon is ambiguous (a timestamp, a port); a whole input shaped
+# that way is grep output. Prefixes are stripped for detection and put back on
+# output, so `file:line:` context survives into the redacted result.
+# grep marks matching lines `file:NN:` and context lines `file-NN-`, mixing both
+# delimiters in one stream whenever -A/-B/-C is used. Matching only the colon
+# form drops the ratio below the threshold on such a stream, which skips
+# stripping and lets the colon format be chosen anyway — the leak this guard
+# exists to prevent. The filename may not contain whitespace, which keeps the
+# pattern off ordinary content like `command: run --port 8080-9090-x`.
+_GREP_PREFIX = re.compile(r"^(?:\S*?([:-])\d+\1|\d+[:-])")
+_GREP_SEPARATOR = "--"
+_GREP_MIN_LINES = 2
+_GREP_PREFIX_RATIO = 0.8
+
+# A YAML list entry carrying a bare value: `- prod`. There is no key, but there
+# is a value, so it is scanned rather than passed through or redacted wholesale.
+_YAML_LIST_ITEM = re.compile(r"^(\s*-\s+)(\S.*)$")
 
 # Column widths for --explain output. The key column is capped so one very long
 # key (a grep prefix, a deep JSON path) cannot push every reason off the screen.
@@ -53,8 +79,13 @@ _EXPLAIN_KEY_MAX_WIDTH = 44
 _EXPLAIN_LAYER_WIDTH = 17
 
 # Separator characters by format, in precedence order.
-_SEPARATORS = {"env": ("=",), "ini": ("=", ":")}
-_COMMENT_PREFIXES = {"env": ("#",), "ini": ("#", ";")}
+# YAML separates a mapping key from its value with a colon *and a space*.
+# Splitting on a bare colon would cut `- discord://token@id` at the scheme,
+# leaving `//token@id` as a value under the key `- discord` — which matches
+# nothing, so the token prints. INI keeps the bare colon: `key:value` is valid
+# there, and its values do not usually carry URLs.
+_SEPARATORS = {"env": ("=",), "ini": ("=", ":"), "yaml": ("=", ": ")}
+_COMMENT_PREFIXES = {"env": ("#",), "ini": ("#", ";"), "yaml": ("#",)}
 
 
 class _Report:
@@ -68,6 +99,7 @@ class _Report:
         self.findings: list[tuple[str, int, Finding]] = []
         self.problems: list[str] = []
         self.explanations: list[tuple[str, int, Explanation]] = []
+        self.notes: list[str] = []
 
     def problem(self, source: str, lineno: int, message: str) -> None:
         self.problems.append(f"{source}:{lineno}: {message}")
@@ -80,6 +112,30 @@ def _strip_quotes(value: str) -> tuple[str, str]:
     return "", value
 
 
+def _split_grep_prefixes(text: str) -> list[tuple[str, str]] | None:
+    """Split grep-style `file:line:` prefixes off each line, or None if absent.
+
+    Returns (prefix, remainder) per line so the prefix can be reprinted while
+    only the remainder is parsed. The decision is made for the whole input:
+    one line that happens to start with digits and a colon is ambiguous, an
+    input where nearly every line does is grep output.
+    """
+    lines = text.splitlines()
+    candidates = [line for line in lines if line.strip() and line.strip() != _GREP_SEPARATOR]
+    if len(candidates) < _GREP_MIN_LINES:
+        return None
+
+    matched = sum(1 for line in candidates if _GREP_PREFIX.match(line))
+    if matched < len(candidates) * _GREP_PREFIX_RATIO:
+        return None
+
+    split: list[tuple[str, str]] = []
+    for line in lines:
+        match = _GREP_PREFIX.match(line)
+        split.append((match.group(0), line[match.end() :]) if match else ("", line))
+    return split
+
+
 def _detect_format(text: str, filename: str | None) -> str:
     """Pick a parser from the file extension, falling back to content sniffing."""
     if filename:
@@ -90,6 +146,8 @@ def _detect_format(text: str, filename: str | None) -> str:
             return "json"
         if extension in _INI_EXTENSIONS:
             return "ini"
+        if extension in _YAML_EXTENSIONS:
+            return "yaml"
         if extension in _ENV_EXTENSIONS or lowered.split("/")[-1].startswith(".env"):
             return "env"
 
@@ -100,6 +158,29 @@ def _detect_format(text: str, filename: str | None) -> str:
         bare = line.strip()
         if bare.startswith("[") and bare.endswith("]"):
             return "ini"
+
+    # Colon-separated content only after any grep prefixes have been removed.
+    # Sniffing before that would read grep's own `line:` as the separator and
+    # hand the whole remainder — secret included — to detection as one value.
+    body = _split_grep_prefixes(text)
+    if body is not None:
+        lines = [rest for _, rest in body]
+    elif any(_GREP_PREFIX.match(line) for line in text.splitlines()):
+        # Some lines look prefixed and not enough to strip with confidence.
+        # Refuse the colon format: env redacts what it cannot parse, which is
+        # useless but loud, and that is the right way to be wrong here.
+        return "env"
+    else:
+        lines = text.splitlines()
+    equals = colons = 0
+    for line in lines:
+        bare = line.strip()
+        if not bare or bare.startswith("#"):
+            continue
+        equals += "=" in bare
+        colons += ":" in bare and "=" not in bare.split(":", 1)[0]
+    if colons > equals:
+        return "yaml"
     return "env"
 
 
@@ -116,33 +197,69 @@ def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, r
     comments = _COMMENT_PREFIXES[fmt]
     out: list[str] = []
 
-    for lineno, raw in enumerate(text.splitlines(), 1):
+    rows = _split_grep_prefixes(text)
+    if rows is None:
+        rows = [("", line) for line in text.splitlines()]
+    elif any(prefix for prefix, _ in rows):
+        report.notes.append("detected grep-style line prefixes; stripped before parsing, restored on output")
+
+    for lineno, (prefix, raw) in enumerate(rows, 1):
         stripped = raw.strip()
 
-        if not stripped or stripped.startswith(comments):
-            out.append(raw)
+        # Comments and blanks are judged after the grep prefix is removed.
+        # `compose.yaml:24:# note` does not start with '#', which is why piped
+        # comments used to be redacted while the same file read directly was fine.
+        if not stripped or stripped.startswith(comments) or stripped == _GREP_SEPARATOR:
+            out.append(prefix + raw)
             continue
 
-        if fmt == "ini" and stripped.startswith("[") and stripped.endswith("]"):
-            out.append(raw)
+        if fmt in ("ini", "yaml") and stripped.startswith("[") and stripped.endswith("]"):
+            out.append(prefix + raw)
             continue
 
-        positions = [raw.find(sep) for sep in separators if raw.find(sep) != -1]
-        if not positions:
+        # `services:` opens a block. There is no value slot on the line, so
+        # there is nothing to screen and nothing to vouch for.
+        if fmt == "yaml" and stripped.endswith(":"):
+            out.append(prefix + raw)
+            continue
+
+        found = [(raw.find(sep), sep) for sep in separators if raw.find(sep) != -1]
+        if not found:
+            # A YAML list entry has a value but no key, so it is scanned as one
+            # rather than redacted for lacking a separator it was never going
+            # to have.
+            item = _YAML_LIST_ITEM.match(raw) if fmt == "yaml" else None
+            if item is not None:
+                marker, content = item.group(1), item.group(2)
+                redacted, unscanned = _redact_value("", content, args.mode, args.replacement)
+                if args.explain:
+                    report.explanations.append((source, lineno, explain_pair("", content, mode=args.mode)))
+                if args.audit:
+                    finding = audit_pair("", content, mode=args.mode)
+                    if finding is not None:
+                        report.findings.append((source, lineno, finding))
+                    continue
+                if unscanned:
+                    report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
+                out.append(f"{prefix}{marker}{redacted}")
+                continue
+
             # Structurally unparseable. Redact rather than echo it — an unparsed
             # line is exactly the one we cannot vouch for.
             report.problem(source, lineno, "no key=value separator; line redacted unscanned")
             out.append(args.replacement)
             continue
 
-        split_at = min(positions)
-        separator = raw[split_at]  # preserve ':' vs '=' rather than normalising
+        # preserve the separator as written rather than normalising it
+        split_at, separator = min(found)
         # `left` is echoed verbatim so that spacing and any `export ` prefix survive
         # the round trip; only the detection key is normalised.
-        left, value = raw[:split_at], raw[split_at + 1 :]
+        left, value = raw[:split_at], raw[split_at + len(separator) :]
         key = left.strip()
         if fmt == "env" and key.startswith("export "):
             key = key[len("export ") :].strip()
+        if fmt == "yaml" and key.startswith("- "):
+            key = key[2:].strip()
 
         quote, inner = _strip_quotes(value.strip())
         leading = value[: len(value) - len(value.lstrip())]
@@ -161,7 +278,7 @@ def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, r
         redacted, unscanned = _redact_value(key, inner, args.mode, args.replacement)
         if unscanned:
             report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
-        out.append(f"{left}{separator}{leading}{quote}{redacted}{quote}")
+        out.append(f"{prefix}{left}{separator}{leading}{quote}{redacted}{quote}")
 
     return out
 
@@ -301,6 +418,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         for line in lines:
             print(line)
+
+    for note in dict.fromkeys(report.notes):
+        print(f"secretscreen: {note}", file=sys.stderr)
 
     _print_explanations(report)
 

--- a/tests/test_yaml_and_prefixes.py
+++ b/tests/test_yaml_and_prefixes.py
@@ -1,0 +1,248 @@
+"""Tests for YAML-shaped input and grep-style line prefixes.
+
+Two failures motivated these. Piping `grep -n` output into the CLI redacted
+every line, because grep's `file:NN:` prefix means a comment no longer starts
+with '#' and a `key: value` line no longer splits where it looks like it should.
+Teaching the format sniffer about colons *without* removing those prefixes is
+worse than leaving it alone: the first colon then belongs to grep's line number,
+the rest of the line becomes one opaque value, and the secret prints in full.
+
+So the prefix handling is not a convenience feature. It is the precondition
+that makes colon-separated auto-detection safe, and most of what follows is
+there to keep it that way.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from secretscreen._cli import EXIT_ERROR, EXIT_FINDINGS, EXIT_OK, main
+
+SECRET = "faketokenvalue123"
+
+COMPOSE = f"""\
+# Watchtower stack
+services:
+  watchtower:
+    image: containrrr/watchtower
+    environment:
+      WATCHTOWER_NOTIFICATION_URL: discord://{SECRET}@1234567890
+      WATCHTOWER_CLEANUP: "true"
+    # keep an eye on this one
+    restart: unless-stopped
+"""
+
+
+def _write(tmp_path, name: str, content: str) -> str:
+    path = tmp_path / name
+    path.write_text(content)
+    return str(path)
+
+
+def _grep(text: str, delimiter: str = ":", filename: str = "") -> str:
+    """Reproduce grep -n output. Context lines use '-', matches use ':'."""
+    prefix = f"{filename}{delimiter}" if filename else ""
+    return "".join(f"{prefix}{n}{delimiter}{line}\n" for n, line in enumerate(text.splitlines(), 1))
+
+
+class TestYamlFormat:
+    """Line-oriented YAML: structure and comments survive, values are screened."""
+
+    def test_structure_comments_and_indentation_survive(self, tmp_path, capsys) -> None:
+        code = main([_write(tmp_path, "compose.yaml", COMPOSE)])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_OK
+        assert SECRET not in out
+        assert "# Watchtower stack" in out
+        assert "    # keep an eye on this one" in out
+        assert "  watchtower:" in out
+        assert "    image: containrrr/watchtower" in out
+        assert 'WATCHTOWER_CLEANUP: "true"' in out
+
+    @pytest.mark.parametrize("name", ["compose.yaml", "docker-compose.yml", "stack.YAML"])
+    def test_detected_from_extension(self, tmp_path, capsys, name: str) -> None:
+        main([_write(tmp_path, name, COMPOSE)])
+        assert SECRET not in capsys.readouterr().out
+
+    def test_detected_from_content_without_an_extension(self, tmp_path, capsys) -> None:
+        main([_write(tmp_path, "stackfile", COMPOSE)])
+        out = capsys.readouterr().out
+        assert SECRET not in out
+        assert "  watchtower:" in out
+
+    def test_key_only_lines_are_structural(self, tmp_path, capsys) -> None:
+        """`services:` has no value slot, so there is nothing to vouch for."""
+        main([_write(tmp_path, "c.yaml", "services:\n  app:\n    ports:\n")])
+        assert capsys.readouterr().out == "services:\n  app:\n    ports:\n"
+
+    def test_list_entries_with_a_separator(self, tmp_path, capsys) -> None:
+        content = "environment:\n  - DB_PASSWORD=hunter2\n  - PUBLIC_HOST=example.com\n"
+        main([_write(tmp_path, "c.yaml", content)])
+        out = capsys.readouterr().out
+
+        assert "hunter2" not in out
+        assert "- PUBLIC_HOST=example.com" in out
+
+    def test_bare_list_entries_are_scanned_not_redacted(self, tmp_path, capsys) -> None:
+        """A bare item has a value but no key; it is screened, not discarded."""
+        content = f"tags:\n  - prod\n  - eu-west-1\nsecrets:\n  - discord://{SECRET}@123\n"
+        code = main([_write(tmp_path, "c.yaml", content)])
+        out = capsys.readouterr().out
+
+        assert "  - prod" in out
+        assert "  - eu-west-1" in out
+        assert SECRET not in out
+        assert code == EXIT_OK
+
+    def test_bare_list_entries_under_audit(self, tmp_path, capsys) -> None:
+        content = f"secrets:\n  - discord://{SECRET}@123\n  - plainvalue\n"
+        code = main([_write(tmp_path, "c.yaml", content), "--audit"])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_FINDINGS
+        assert "url_credentials" in captured.out
+        assert SECRET not in captured.out
+
+    def test_bare_list_entries_under_explain(self, tmp_path, capsys) -> None:
+        content = f"secrets:\n  - discord://{SECRET}@123\n  - plainvalue\n"
+        main([_write(tmp_path, "c.yaml", content), "--explain"])
+        err = capsys.readouterr().err
+
+        assert "redacted" in err
+        assert "clean" in err
+        assert SECRET not in err
+
+    def test_oversized_bare_list_entry_is_reported_unscanned(self, tmp_path, capsys) -> None:
+        content = "blobs:\n  - " + "x" * 70_000 + "\n"
+        code = main([_write(tmp_path, "c.yaml", content)])
+
+        assert code == EXIT_ERROR
+        assert "scan cap" in capsys.readouterr().err
+
+    def test_block_scalar_body_is_redacted_and_reported(self, tmp_path, capsys) -> None:
+        """A documented limit: this is line-oriented, not a real YAML parse."""
+        content = f"command: >\n  --token {SECRET}\n"
+        code = main([_write(tmp_path, "c.yaml", content)])
+        captured = capsys.readouterr()
+
+        assert SECRET not in captured.out
+        assert code == EXIT_ERROR
+        assert "no key=value separator" in captured.err
+
+
+class TestGrepPrefixes:
+    """grep's `file:NN:` and `file-NN-` markers, stripped for parsing only."""
+
+    @pytest.mark.parametrize("delimiter", [":", "-"])
+    @pytest.mark.parametrize("filename", ["", "compose.yaml", "stacks/wt/compose.yaml"])
+    def test_secret_never_survives_any_prefix_shape(self, monkeypatch, capsys, delimiter, filename) -> None:
+        monkeypatch.setattr("sys.stdin", _Stdin(_grep(COMPOSE, delimiter, filename)))
+        main([])
+        assert SECRET not in capsys.readouterr().out
+
+    def test_prefix_is_restored_on_output(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr("sys.stdin", _Stdin(_grep(COMPOSE, ":", "compose.yaml")))
+        main([])
+        out = capsys.readouterr().out
+
+        assert "compose.yaml:6:" in out
+        assert "compose.yaml:1:# Watchtower stack" in out
+
+    def test_comments_survive_a_prefix(self, monkeypatch, capsys) -> None:
+        """The original bug: a prefixed comment no longer starts with '#'."""
+        monkeypatch.setattr("sys.stdin", _Stdin("f.yaml:1:# a comment\nf.yaml:2:key: value\n"))
+        code = main([])
+        captured = capsys.readouterr()
+
+        assert "f.yaml:1:# a comment" in captured.out
+        assert code == EXIT_OK
+        assert "redacted unscanned" not in captured.err
+
+    def test_context_separator_passes_through(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr("sys.stdin", _Stdin("f.env:1:A=1\n--\nf.env:9:B=2\n"))
+        code = main([])
+
+        assert "--" in capsys.readouterr().out
+        assert code == EXIT_OK
+
+    def test_mixed_match_and_context_delimiters(self, monkeypatch, capsys) -> None:
+        """grep -A/-B/-C emits ':' and '-' markers in one stream.
+
+        Matching only ':' drops the ratio below the threshold, which skips
+        stripping and lets the colon format be chosen anyway — the leak.
+        """
+        stream = f'c.yaml:6:      URL: discord://{SECRET}@123\nc.yaml-7-      CLEANUP: "true"\nc.yaml-8-      X: y\n'
+        monkeypatch.setattr("sys.stdin", _Stdin(stream))
+        main([])
+        out = capsys.readouterr().out
+
+        assert SECRET not in out
+        assert "c.yaml-7-" in out
+
+    def test_a_note_announces_the_reinterpretation(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr("sys.stdin", _Stdin(_grep(COMPOSE, ":", "compose.yaml")))
+        main([])
+        assert "grep-style line prefixes" in capsys.readouterr().err
+
+    def test_detection_key_excludes_the_prefix(self, monkeypatch, capsys) -> None:
+        """Explain reports the real key, not `compose.yaml:6:KEY`."""
+        monkeypatch.setattr("sys.stdin", _Stdin("f.env:1:DB_PASSWORD=hunter2\nf.env:2:LOG=debug\n"))
+        main(["--explain"])
+        err = capsys.readouterr().err
+
+        assert "  DB_PASSWORD " in err
+        assert "f.env:1:DB_PASSWORD" not in err
+
+
+class TestPrefixDetectionIsConservative:
+    """Ordinary content must not be mistaken for grep output, and vice versa."""
+
+    def test_content_resembling_a_prefix_is_left_alone(self, tmp_path, capsys) -> None:
+        content = "command: run --port 8080-9090-x\nimage: nginx:1.25\nurl: http://host:8080/p\n"
+        main([_write(tmp_path, "c.yaml", content)])
+        assert capsys.readouterr().out == content
+
+    def test_partially_prefixed_input_refuses_the_colon_format(self, monkeypatch, capsys) -> None:
+        """Ambiguous input falls back to env: useless but loud beats quiet.
+
+        Choosing the colon format here would split on grep's line number and
+        hand the remainder to detection as one unmatched value.
+        """
+        stream = f"f.yaml:1:      URL: discord://{SECRET}@123\nplain: value\nanother: value\nmore: value\n"
+        monkeypatch.setattr("sys.stdin", _Stdin(stream))
+        main([])
+        assert SECRET not in capsys.readouterr().out
+
+    def test_single_line_input_is_not_treated_as_prefixed(self, monkeypatch, capsys) -> None:
+        """One line starting with digits and a colon is a timestamp, not grep.
+
+        The requirement is that it is never silently re-split into a key and a
+        value nobody screened. Falling into the unparseable path is correct:
+        redacted, reported, non-zero exit.
+        """
+        monkeypatch.setattr("sys.stdin", _Stdin("12:34:56 starting up\n"))
+        code = main([])
+        captured = capsys.readouterr()
+
+        assert captured.out.strip() == "[REDACTED]"
+        assert code == EXIT_ERROR
+        assert "redacted unscanned" in captured.err
+
+    def test_env_file_with_prefixes_still_parses(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr("sys.stdin", _Stdin("a.env:1:DB_PASSWORD=hunter2\na.env:2:LOG_LEVEL=debug\n"))
+        main([])
+        out = capsys.readouterr().out
+
+        assert "hunter2" not in out
+        assert "a.env:2:LOG_LEVEL=debug" in out
+
+
+class _Stdin:
+    """Minimal stdin stand-in; the CLI only ever calls read()."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text


### PR DESCRIPTION
Stacked on #28 — base is `feat/explain-flag`, so it retargets to `main` once that merges.

## The report, and what was actually wrong

Piping `grep -n` output in redacted every line. Two causes, and the reported one wasn't the real one:

- **Comments were never the problem.** `#` lines pass through fine on a direct file read. They break only when grep prefixes them — `compose.yaml:24:# note` doesn't start with `#` anymore.
- **YAML was never parsed.** `env` format only splits on `=`, so every `key: value` line looked structurally unparseable.

## Why the ordering mattered

The obvious fix — teach the sniffer about `key: value` — would have been **worse than doing nothing**:

```
$ grep -n 'WATCHTOWER' compose.yaml | secretscreen --format ini   # before
6:      WATCHTOWER_NOTIFICATION_URL: discord://faketokenvalue123@1234567890
```

The first colon belongs to grep's line number. The key becomes `6`, the whole remainder becomes one opaque value nothing matches, and the token prints. A loud useless failure becomes a silent leak.

So prefix stripping is a precondition, not a parallel nicety, and when the input is only *partly* prefixed the sniffer refuses the colon format and falls back to `env` — which redacts what it can't parse. Useless beats quiet.

## Two bugs the tests caught in my own work

**grep's context delimiter.** `-A/-B/-C` emit `file-NN-` for context lines alongside `file:NN:` for matches. My first prefix pattern matched only the colon form, so a mixed stream fell below the detection threshold — stripping skipped, colon detection fired anyway, secret printed. Exactly the failure the guard exists to prevent, reintroduced by the guard being incomplete. Pinned by a test.

**Colon-space, not colon.** Splitting YAML on a bare `:` cuts `- discord://token@id` at the scheme, leaving `//token@id` under the key `- discord`, which matches nothing. YAML's mapping separator is colon-*space*. Found by the bare-list-entry test.

## Behaviour

Block openers (`services:`) have no value slot and pass through. Bare list entries have a value but no key, so they're scanned as values rather than redacted for lacking a separator they were never going to have. Prefixes are restored on output, so file-and-line context survives into the redacted result.

Detection is document-wide, not per-line — one line starting with digits and a colon is a timestamp; a whole input shaped that way is grep. A stderr note announces the reinterpretation.

## Deliberate limits

- **Line-oriented, not a real YAML parse.** A parser means a third-party dependency and the package is stdlib-only by architecture test. Block scalar bodies stay unparseable and keep being redacted and reported.
- **Mixed-format streams** (`grep -rn` across `.env` and `.yaml`) pick the majority format and redact the rest wholesale. Loud and safe rather than half-parsed. Documented in the README.

## Tests

294 → 322. Covers every grep prefix shape (`:` and `-`, with and without filename, single and multi-file), the mixed-delimiter regression, prefix restoration, comments surviving a prefix, `--` separators, ambiguous partial-prefix refusal, content that merely resembles a prefix (`command: run --port 8080-9090-x`) being left alone, YAML structure/list/block-scalar handling, and bare list entries under redact, `--audit`, `--explain`, and the size cap.