### PR TITLE
ci: run CI and CodeQL on pull requests to any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter. Gating on the base branch means a stacked pull
+  # request — one opened against another feature branch — runs nothing, and
+  # reports only the skipped automerge job, which reads like a pass. Push is
+  # still limited to main so feature-branch pushes do not double-run.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,11 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  # No `branches:` filter. Gating on the base branch means a stacked pull
+  # request — one opened against another feature branch — runs nothing, and
+  # reports only the skipped automerge job, which reads like a pass. Push is
+  # still limited to main so feature-branch pushes do not double-run.
   pull_request:
-    branches: [main]
   schedule:
     - cron: "0 6 * * 3"
 


### PR DESCRIPTION
`ci.yml` and `codeql.yml` both gated `pull_request` on `branches: [main]`, so a **stacked pull request — one opened against another feature branch — ran nothing at all.**

The failure mode is what makes it worth fixing rather than working around: the checks list isn't empty, it shows the skipped dependabot automerge job. That reads like a pass rather than an absence. #29 was reviewed that way; its matrix had to be run locally instead, which is my word rather than CI's.

Dropping the filter means any PR gets the full matrix, lint, and CodeQL regardless of base. `push` stays limited to `main`, so pushing a feature branch doesn't double-run alongside its own PR.

**For the PRs already open:** `pull_request` events use the workflow file from the head ref, so #28 and #29 only pick this up once it's merged into their branches — merging this first and then landing them in order does that naturally.