### PR TITLE
feat: config files, show/hide rules, --version and a real --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,27 @@ Order: user config, then `.secretscreen.toml` files discovered upward from **eac
 
 **`hide` takes globs. `show` does not.** `show = ["*_KEY"]` would print `AWS_SECRET_ACCESS_KEY`, and it would go on matching keys nobody has written yet. Every show entry is a credential you are choosing to print, so every entry gets named in full. `hide` always wins over `show`, at every scope.
 
-**A discovered project config may tighten redaction but not relax it.** Its `show` entries are ignored unless you pass `--trust-config`, because a `.secretscreen.toml` can arrive with a repository you cloned five minutes ago, and which of your credentials get printed is not that author's decision. Only your own `~/.config` file can loosen anything.
+The same asymmetry decides what a rule can cover in JSON. `hide` names a key and takes whatever that key holds — a string, a port number, a whole object — and replaces all of it, because the shape and key names of a hidden subtree are usually the half worth hiding. `show` is honoured for a string and refused for anything else, with a note on stderr: vouching for one named key is a decision about one value, and vouching for an object is a decision about values nobody has added yet. In a `--format dsn` stream the whole line is the value, and rules match the key `dsn`.
+
+**A discovered project config may tighten redaction but not relax it.** A `.secretscreen.toml` can arrive with a repository you cloned five minutes ago, or be dropped in a shared directory by anyone who can write there, so every setting one carries is read as a request to tighten:
+
+| setting | from a discovered config |
+|---|---|
+| `hide` | applied |
+| `show` | ignored |
+| `[detection] mode` | only `normal` → `aggressive` |
+| `[detection] entropy_threshold` | only downward |
+| `root` | ignored |
+
+`--trust-config` honours all five. Each ignored setting is named on stderr, so a rule that did not fire says so rather than looking like one that did.
+
+The three settings below `show` matter as much as `show` does. `show` prints a credential and is the obvious one; `entropy_threshold = 99` and `mode = "normal"` stop a credential being *found*, and `root = true` needs no rules of its own — it ends the upward walk before your own config one directory up is ever read. All four end with a secret on stdout and `--audit` exiting 0.
+
+Only your own `~/.config` file, or a file you name yourself with `--config`, can loosen anything.
 
 Every loaded config is named on stderr, and a malformed one — bad TOML, an unknown setting, a wildcard where none is allowed — is fatal rather than skipped. A typo that silently disabled a `hide` rule would leave you believing you had configured something you had not.
 
-Equivalent flags exist for one-off use: `--show KEY`, `--hide GLOB`, `--entropy-threshold N`, `--config FILE`, `--no-config`.
+Equivalent flags exist for one-off use: `--show KEY`, `--hide GLOB`, `--entropy-threshold N`, `--no-config`, and `--config FILE` — which uses that file *only*, skipping both discovery and your own `~/.config`, and trusts it because you named it.
 
 ### Knowing what was left alone
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ That stripping is what makes colon-separated detection safe to attempt at all. W
 
 One case stays deliberately blunt: a single stream mixing formats, such as `grep -rn` across both `.env` and `.yaml` files, picks the majority format and redacts the rest wholesale. Loud and safe rather than half-parsed.
 
+### Config
+
+Once you have found a false positive, `--explain` tells you which key it was. A config file stops you diagnosing it again next run.
+
+```toml
+# ~/.config/secretscreen.toml   or   .secretscreen.toml beside a stack
+
+# Never redact these. Exact key names — no wildcards.
+show = ["DEPLOY_PUBLIC_KEY"]
+
+# Always redact these. Globs are fine.
+hide = ["*_NOTIFICATION_URL", "*_WEBHOOK_URL"]
+
+[detection]
+mode = "normal"            # normal | aggressive
+entropy_threshold = 4.5
+
+# Applies only while this filename is being processed.
+[files."demo.env"]
+show = ["API_TOKEN"]
+```
+
+Order: user config, then `.secretscreen.toml` files discovered upward from **each input file**, nearest last, then flags. Lists union rather than replace, so a closer file extends the broader one instead of silently discarding it. Discovery runs per input, so `secretscreen a/compose.yaml b/compose.yaml` can pick up a different config beside each. Add `root = true` to stop the upward walk.
+
+**`hide` takes globs. `show` does not.** `show = ["*_KEY"]` would print `AWS_SECRET_ACCESS_KEY`, and it would go on matching keys nobody has written yet. Every show entry is a credential you are choosing to print, so every entry gets named in full. `hide` always wins over `show`, at every scope.
+
+**A discovered project config may tighten redaction but not relax it.** Its `show` entries are ignored unless you pass `--trust-config`, because a `.secretscreen.toml` can arrive with a repository you cloned five minutes ago, and which of your credentials get printed is not that author's decision. Only your own `~/.config` file can loosen anything.
+
+Every loaded config is named on stderr, and a malformed one — bad TOML, an unknown setting, a wildcard where none is allowed — is fatal rather than skipped. A typo that silently disabled a `hide` rule would leave you believing you had configured something you had not.
+
+Equivalent flags exist for one-off use: `--show KEY`, `--hide GLOB`, `--entropy-threshold N`, `--config FILE`, `--no-config`.
+
 ### Knowing what was left alone
 
 A missed secret is invisible: the output looks screened and nothing says otherwise. `--explain` writes an account of every value to **stderr**, so stdout stays a usable redacted stream and `secretscreen app.env --explain > clean.env` still works.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "secretscreen"
-version = "0.4.1"
+version = "0.5.0"
 description = "Detect and redact secrets in key-value pairs, dicts, and environment variables. Library and CLI."
 readme = "README.md"
 license = "MIT"

--- a/src/secretscreen/__init__.py
+++ b/src/secretscreen/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "redact_pair",
 ]
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/src/secretscreen/_cli.py
+++ b/src/secretscreen/_cli.py
@@ -204,7 +204,7 @@ def _detect_format(text: str, filename: str | None) -> str:
     return "env"
 
 
-def _resolve_settings(path: str | None, args: argparse.Namespace, report: _Report) -> _Settings:
+def _resolve_settings(path: str | None, args: argparse.Namespace, report: _Report, loader: _config.Loader) -> _Settings:
     """Fold config files and command-line flags into settings for one input.
 
     Discovery runs per input, not once per process: `secretscreen a/compose.yaml
@@ -216,15 +216,15 @@ def _resolve_settings(path: str | None, args: argparse.Namespace, report: _Repor
     merged = Config()
 
     if args.config:
-        merged = _config.merge(merged, _config.load(Path(args.config)))
+        merged = _config.merge(merged, loader.load(Path(args.config)))
     elif not args.no_config:
         user = _config.user_config_path()
         if user.is_file():
-            merged = _config.merge(merged, _config.load(user))
+            merged = _config.merge(merged, loader.load(user))
 
         start = Path(path).absolute().parent if path else Path.cwd()
-        for found in _config.discover(start, honour_root=args.trust_config):
-            discovered = _config.load(found)
+        for found in loader.discover(start, honour_root=args.trust_config):
+            discovered = loader.load(found)
             if args.trust_config:
                 merged = _config.merge(merged, discovered)
                 continue
@@ -762,6 +762,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args.mode = Mode.AGGRESSIVE if args.aggressive else None
 
     report = _Report()
+    # One loader for the run: discovery repeats per input, and the files it
+    # finds do not change underneath a single invocation.
+    loader = _config.Loader()
     sources = args.files or ["-"]
     lines: list[str] = []
 
@@ -771,7 +774,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             continue
 
         try:
-            settings = _resolve_settings(None if path == "-" else path, args, report)
+            settings = _resolve_settings(None if path == "-" else path, args, report, loader)
         except ConfigError as exc:
             # Fatal rather than skipped: continuing would screen this input with
             # rules the user believes are in force and are not.

--- a/src/secretscreen/_cli.py
+++ b/src/secretscreen/_cli.py
@@ -27,6 +27,7 @@ from secretscreen import __version__, _config
 from secretscreen._config import Config, ConfigError
 from secretscreen._core import (
     _MAX_DETECT_LENGTH,
+    _MAX_RECURSIVE_DEPTH,
     REDACTED,
     STATE_REDACTED,
     STATE_VETOED,
@@ -83,11 +84,9 @@ _YAML_LIST_ITEM = re.compile(r"^(\s*-\s+)(\S.*)$")
 # key (a grep prefix, a deep JSON path) cannot push every reason off the screen.
 _EXPLAIN_KEY_MAX_WIDTH = 44
 
-# Mirrors the library default; used when neither a flag nor a config sets one.
-_DEFAULT_ENTROPY_THRESHOLD = 4.5
-
-# Matches _core._MAX_RECURSIVE_DEPTH so the rule overlay stops where redaction did.
-_JSON_RULE_MAX_DEPTH = 100
+# Imported rather than repeated: the rule overlay has to stop exactly where
+# redaction did, and a comment saying two literals agree is not a mechanism.
+_JSON_RULE_MAX_DEPTH = _MAX_RECURSIVE_DEPTH
 _EXPLAIN_LAYER_WIDTH = 17
 
 # Separator characters by format, in precedence order.
@@ -214,31 +213,30 @@ def _resolve_settings(path: str | None, args: argparse.Namespace, report: _Repor
     nearest, then flags — so the closest file wins and an explicit flag beats
     every file.
     """
-    layers: list[Config] = []
+    merged = Config()
 
     if args.config:
-        layers.append(_config.load(Path(args.config)))
+        merged = _config.merge(merged, _config.load(Path(args.config)))
     elif not args.no_config:
         user = _config.user_config_path()
         if user.is_file():
-            layers.append(_config.load(user))
+            merged = _config.merge(merged, _config.load(user))
 
         start = Path(path).absolute().parent if path else Path.cwd()
-        for found in _config.discover(start):
+        for found in _config.discover(start, honour_root=args.trust_config):
             discovered = _config.load(found)
-            if not args.trust_config:
-                # A discovered file may tighten redaction but not loosen it:
-                # it may have arrived with a repository rather than being
-                # written by whoever is running the command.
-                before = discovered.show
-                discovered = _config.without_show(discovered)
-                if before:
-                    report.notes.append(f"{found}: show entries ignored (pass --trust-config to honour them)")
-            layers.append(discovered)
+            if args.trust_config:
+                merged = _config.merge(merged, discovered)
+                continue
+            # A discovered file may tighten redaction but not loosen it: it
+            # may have arrived with a repository rather than being written by
+            # whoever is running the command.
+            if _config.drops_show(discovered):
+                report.notes.append(f"{found}: show entries ignored (pass --trust-config to honour them)")
+            if discovered.root:
+                report.notes.append(f"{found}: root ignored (pass --trust-config to honour it)")
+            merged = _config.merge_tightening(merged, discovered)
 
-    merged = Config()
-    for layer in layers:
-        merged = _config.merge(merged, layer)
     if path:
         merged = merged.for_file(Path(path).name)
 
@@ -255,7 +253,9 @@ def _resolve_settings(path: str | None, args: argparse.Namespace, report: _Repor
 
     threshold = args.entropy_threshold
     if threshold is None:
-        threshold = merged.entropy_threshold if merged.entropy_threshold is not None else _DEFAULT_ENTROPY_THRESHOLD
+        threshold = (
+            merged.entropy_threshold if merged.entropy_threshold is not None else _config.DEFAULT_ENTROPY_THRESHOLD
+        )
 
     return _Settings(mode=mode, entropy_threshold=threshold, config=merged)
 
@@ -275,6 +275,57 @@ def _rule_explanation(key: str, kind: str, name: str) -> Explanation:
     if kind == "hide":
         return Explanation(key, STATE_REDACTED, "rule", f"hide rule {name!r}")
     return Explanation(key, STATE_VETOED, "rule", f"show rule {name!r} — not examined")
+
+
+def _ancestors(path: str) -> list[str]:
+    """Plain key names of every container a display path passes through.
+
+    `services[0].db.region` came from `services`, then `db`. Index suffixes
+    are dropped: the list belongs to the key, and a rule names the key.
+    """
+    segments = path.split(".")[:-1]
+    return [segment.split("[", 1)[0] for segment in segments if segment]
+
+
+def _rule_covering(explanation: Explanation, config: Config) -> tuple[str, str] | None:
+    """The rule that decided this value, including one applied further up.
+
+    A hide rule replaces everything under the key it names, so an account of
+    what happened to a value inside that subtree has to name the rule rather
+    than the layer that would have run. show does not inherit downward — it
+    vouches for one named key, not for whatever the key contains.
+    """
+    direct = _rule_for(explanation.name or explanation.key, config)
+    if direct is not None:
+        return direct
+    for ancestor in _ancestors(explanation.key):
+        hidden = config.hides(ancestor)
+        if hidden is not None:
+            return ("hide", hidden)
+    return None
+
+
+def _shown_non_strings(data: object, config: Config, _depth: int = 0) -> list[str]:
+    """Keys a show rule names whose value is not a string.
+
+    Reported rather than obeyed. Restoring an object or an array would vouch
+    for every value inside it, including ones added later — the same argument
+    that keeps wildcards out of show. Silence is the one option not available:
+    a rule that neither fires nor complains reads as a rule in force.
+    """
+    if _depth >= _JSON_RULE_MAX_DEPTH:
+        return []
+    found: list[str] = []
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if not isinstance(value, str) and config.shows(str(key)) is not None:
+                found.append(str(key))
+            if isinstance(value, (dict, list)):
+                found.extend(_shown_non_strings(value, config, _depth + 1))
+    elif isinstance(data, list):
+        for item in data:
+            found.extend(_shown_non_strings(item, config, _depth + 1))
+    return found
 
 
 def _rule_for(key: str, config: Config) -> tuple[str, str] | None:
@@ -428,15 +479,24 @@ def _process_json(text: str, source: str, args: argparse.Namespace, settings: _S
         report.problem(source, exc.lineno, f"invalid JSON ({exc.msg}); nothing printed")
         return []
 
-    rules = settings.config.show or settings.config.hide
+    rules = settings.config.has_rules
+
+    if rules:
+        for key in _shown_non_strings(data, settings.config):
+            report.notes.append(f"show rule {key!r} names a value that is not a string; ignored")
 
     if args.explain:
         for explanation in explain_dict(data, mode=settings.mode, entropy_threshold=settings.entropy_threshold):
-            rule = _rule_for(explanation.key, settings.config) if rules else None
+            # Rules match the plain key, never the display path: `hide =
+            # ["region"]` has to fire on services[0].db.region, and an account
+            # that says `clean` while stdout says [REDACTED] is worse than no
+            # account at all.
+            rule = _rule_covering(explanation, settings.config) if rules else None
             resolved = _rule_explanation(explanation.key, *rule) if rule else explanation
             report.explanations.append((source, 0, resolved))
 
     if args.audit:
+        reported: set[str] = set()
         for finding in audit_dict(data, mode=settings.mode, entropy_threshold=settings.entropy_threshold):
             # Match on the rule kind, not on the entry spelling: matching is
             # case-insensitive everywhere else, and an --audit that reported a
@@ -444,9 +504,16 @@ def _process_json(text: str, source: str, args: argparse.Namespace, settings: _S
             rule = _rule_for(finding.key, settings.config) if rules else None
             if rule is not None and rule[0] == "show":
                 continue
+            reported.add(finding.key.lower())
             report.findings.append((source, 0, finding))
         if rules:
+            # Only keys no layer already reported. A hide rule on a key
+            # detection also catches is one finding, not two — anything
+            # counting or diffing --audit output would see the duplicate.
             for key in _hidden_keys(data, settings.config):
+                if key.lower() in reported:
+                    continue
+                reported.add(key.lower())
                 report.findings.append((source, 0, _rule_finding(key, settings.config.hides(key) or "")))
         return []
 
@@ -467,6 +534,14 @@ def _apply_rules_to_structure(
     value, a show rule restores the original, and everything else keeps what
     detection decided. Working from redact_dict's output rather than
     reimplementing it keeps partial URL redaction and the depth caps intact.
+
+    A hide rule covers whatever the key holds — an object, an array, a port
+    number — and replaces the whole of it. Redacting only the leaves inside
+    would leave the shape of a hidden subtree on display, and its key names
+    are usually the half worth hiding. A show rule is the asymmetric case: it
+    is honoured for a string and refused for anything else, because vouching
+    for one named key is a decision about one value, and vouching for a
+    subtree is a decision about values nobody has added yet.
     """
     if _depth >= _JSON_RULE_MAX_DEPTH:
         return redacted
@@ -477,8 +552,10 @@ def _apply_rules_to_structure(
             key_str = str(key)
             current = redacted.get(key)
             rule = _rule_for(key_str, config)
-            if rule is not None and isinstance(value, str):
-                result[key] = replacement if rule[0] == "hide" else value
+            if rule is not None and rule[0] == "hide":
+                result[key] = replacement
+            elif rule is not None and isinstance(value, str):
+                result[key] = value
             elif isinstance(value, (dict, list)):
                 result[key] = _apply_rules_to_structure(value, current, config, replacement, _depth + 1)
             else:
@@ -495,13 +572,17 @@ def _apply_rules_to_structure(
 
 
 def _hidden_keys(data: object, config: Config, _depth: int = 0) -> list[str]:
-    """Keys a hide rule covers, so --audit reports them as findings."""
+    """Keys a hide rule covers, so --audit reports them as findings.
+
+    Whatever the key holds, matching redaction: a hidden object is one
+    finding for the object, not a walk of everything inside it.
+    """
     if _depth >= _JSON_RULE_MAX_DEPTH:
         return []
     found: list[str] = []
     if isinstance(data, dict):
         for key, value in data.items():
-            if isinstance(value, str) and config.hides(str(key)) is not None:
+            if config.hides(str(key)) is not None:
                 found.append(str(key))
             elif isinstance(value, (dict, list)):
                 found.extend(_hidden_keys(value, config, _depth + 1))
@@ -654,8 +735,16 @@ def _build_parser() -> argparse.ArgumentParser:
         help="always redact keys matching this glob. Repeatable.",
     )
     parser.add_argument("--entropy-threshold", type=float, metavar="N", help="entropy cutoff (default: 4.5)")
-    parser.add_argument("--config", metavar="FILE", help="use this config file and skip discovery")
-    parser.add_argument("--no-config", action="store_true", help="ignore all config files")
+    # Mutually exclusive rather than one silently winning: --no-config says
+    # "ignore all config files", and honouring one anyway is the difference
+    # between a flag that did nothing and a flag that did the opposite.
+    sources = parser.add_mutually_exclusive_group()
+    sources.add_argument(
+        "--config",
+        metavar="FILE",
+        help="use only this config file: skips discovery and the user config, and is trusted",
+    )
+    sources.add_argument("--no-config", action="store_true", help="ignore all config files")
     parser.add_argument(
         "--trust-config",
         action="store_true",

--- a/src/secretscreen/_cli.py
+++ b/src/secretscreen/_cli.py
@@ -19,11 +19,19 @@ import argparse
 import json
 import re
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+from secretscreen import __version__, _config
+from secretscreen._config import Config, ConfigError
 from secretscreen._core import (
     _MAX_DETECT_LENGTH,
     REDACTED,
+    STATE_REDACTED,
+    STATE_VETOED,
+    Explanation,
+    Finding,
     Mode,
     audit_dict,
     audit_pair,
@@ -35,8 +43,6 @@ from secretscreen._core import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-    from secretscreen._core import Explanation, Finding
 
 EXIT_OK = 0
 EXIT_FINDINGS = 1
@@ -76,6 +82,12 @@ _YAML_LIST_ITEM = re.compile(r"^(\s*-\s+)(\S.*)$")
 # Column widths for --explain output. The key column is capped so one very long
 # key (a grep prefix, a deep JSON path) cannot push every reason off the screen.
 _EXPLAIN_KEY_MAX_WIDTH = 44
+
+# Mirrors the library default; used when neither a flag nor a config sets one.
+_DEFAULT_ENTROPY_THRESHOLD = 4.5
+
+# Matches _core._MAX_RECURSIVE_DEPTH so the rule overlay stops where redaction did.
+_JSON_RULE_MAX_DEPTH = 100
 _EXPLAIN_LAYER_WIDTH = 17
 
 # Separator characters by format, in precedence order.
@@ -86,6 +98,15 @@ _EXPLAIN_LAYER_WIDTH = 17
 # there, and its values do not usually carry URLs.
 _SEPARATORS = {"env": ("=",), "ini": ("=", ":"), "yaml": ("=", ": ")}
 _COMMENT_PREFIXES = {"env": ("#",), "ini": ("#", ";"), "yaml": ("#",)}
+
+
+@dataclass(frozen=True, slots=True)
+class _Settings:
+    """Everything one input needs, after config and flags are folded together."""
+
+    mode: Mode
+    entropy_threshold: float
+    config: Config
 
 
 class _Report:
@@ -184,14 +205,105 @@ def _detect_format(text: str, filename: str | None) -> str:
     return "env"
 
 
-def _redact_value(key: str, value: str, mode: Mode, replacement: str) -> tuple[str, bool]:
+def _resolve_settings(path: str | None, args: argparse.Namespace, report: _Report) -> _Settings:
+    """Fold config files and command-line flags into settings for one input.
+
+    Discovery runs per input, not once per process: `secretscreen a/compose.yaml
+    b/compose.yaml` must be able to pick up a different `.secretscreen.toml`
+    beside each one. Order is user config, then project configs from furthest to
+    nearest, then flags — so the closest file wins and an explicit flag beats
+    every file.
+    """
+    layers: list[Config] = []
+
+    if args.config:
+        layers.append(_config.load(Path(args.config)))
+    elif not args.no_config:
+        user = _config.user_config_path()
+        if user.is_file():
+            layers.append(_config.load(user))
+
+        start = Path(path).absolute().parent if path else Path.cwd()
+        for found in _config.discover(start):
+            discovered = _config.load(found)
+            if not args.trust_config:
+                # A discovered file may tighten redaction but not loosen it:
+                # it may have arrived with a repository rather than being
+                # written by whoever is running the command.
+                before = discovered.show
+                discovered = _config.without_show(discovered)
+                if before:
+                    report.notes.append(f"{found}: show entries ignored (pass --trust-config to honour them)")
+            layers.append(discovered)
+
+    merged = Config()
+    for layer in layers:
+        merged = _config.merge(merged, layer)
+    if path:
+        merged = merged.for_file(Path(path).name)
+
+    for source in merged.sources:
+        report.notes.append(f"loaded config {source}")
+
+    flag_show = tuple(args.show or ())
+    _config.check_show_entries(flag_show, "--show")
+    merged = _config.merge(merged, Config(show=flag_show, hide=tuple(args.hide or ())))
+
+    mode = args.mode
+    if mode is None:
+        mode = Mode.AGGRESSIVE if merged.mode == "aggressive" else Mode.NORMAL
+
+    threshold = args.entropy_threshold
+    if threshold is None:
+        threshold = merged.entropy_threshold if merged.entropy_threshold is not None else _DEFAULT_ENTROPY_THRESHOLD
+
+    return _Settings(mode=mode, entropy_threshold=threshold, config=merged)
+
+
+def _rule_finding(key: str, pattern: str) -> Finding:
+    """A hide rule redacts without any layer having matched."""
+    return Finding(key=key, reason=f"hide:{pattern}", layer="rule", detail=f"hide rule {pattern!r}")
+
+
+def _rule_explanation(key: str, kind: str, name: str) -> Explanation:
+    """Report a config decision distinctly from a detection one.
+
+    A show rule reads as `vetoed` rather than `clean`: the value was not
+    examined, it was vouched for. That is the line to look at when a rule
+    written a year ago is quietly covering a secret added last week.
+    """
+    if kind == "hide":
+        return Explanation(key, STATE_REDACTED, "rule", f"hide rule {name!r}")
+    return Explanation(key, STATE_VETOED, "rule", f"show rule {name!r} — not examined")
+
+
+def _rule_for(key: str, config: Config) -> tuple[str, str] | None:
+    """Return ("hide"|"show", rule) when a config rule decides this key.
+
+    hide is checked first and wins outright. A narrower rule that could un-hide
+    something would make being more specific make the tool quieter.
+    """
+    hidden = config.hides(key)
+    if hidden is not None:
+        return ("hide", hidden)
+    shown = config.shows(key)
+    if shown is not None:
+        return ("show", shown)
+    return None
+
+
+def _redact_value(key: str, value: str, settings: _Settings, replacement: str) -> tuple[str, bool]:
     """Redact one value. Returns (result, unscanned) — unscanned means the size cap hit."""
-    result = redact_pair(key, value, mode=mode, replacement=replacement)
+    result = redact_pair(
+        key, value, mode=settings.mode, replacement=replacement, entropy_threshold=settings.entropy_threshold
+    )
     unscanned = len(value) > _MAX_DETECT_LENGTH and result == value
     return result, unscanned
 
 
-def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, report: _Report) -> list[str]:
+def _process_lines(
+    text: str, fmt: str, source: str, args: argparse.Namespace, settings: _Settings, report: _Report
+) -> list[str]:
     """Redact a line-oriented format (env, ini), preserving comments and layout."""
     separators = _SEPARATORS[fmt]
     comments = _COMMENT_PREFIXES[fmt]
@@ -231,11 +343,17 @@ def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, r
             item = _YAML_LIST_ITEM.match(raw) if fmt == "yaml" else None
             if item is not None:
                 marker, content = item.group(1), item.group(2)
-                redacted, unscanned = _redact_value("", content, args.mode, args.replacement)
+                redacted, unscanned = _redact_value("", content, settings, args.replacement)
                 if args.explain:
-                    report.explanations.append((source, lineno, explain_pair("", content, mode=args.mode)))
+                    report.explanations.append(
+                        (
+                            source,
+                            lineno,
+                            explain_pair("", content, mode=settings.mode, entropy_threshold=settings.entropy_threshold),
+                        )
+                    )
                 if args.audit:
-                    finding = audit_pair("", content, mode=args.mode)
+                    finding = audit_pair("", content, mode=settings.mode, entropy_threshold=settings.entropy_threshold)
                     if finding is not None:
                         report.findings.append((source, lineno, finding))
                     continue
@@ -264,18 +382,37 @@ def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, r
         quote, inner = _strip_quotes(value.strip())
         leading = value[: len(value) - len(value.lstrip())]
 
+        rule = _rule_for(key, settings.config)
+        if rule is not None:
+            kind, name = rule
+            if args.explain:
+                report.explanations.append((source, lineno, _rule_explanation(key, kind, name)))
+            if args.audit:
+                if kind == "hide":
+                    report.findings.append((source, lineno, _rule_finding(key, name)))
+                continue
+            body = args.replacement if kind == "hide" else inner
+            out.append(f"{prefix}{left}{separator}{leading}{quote}{body}{quote}")
+            continue
+
         if args.explain:
-            report.explanations.append((source, lineno, explain_pair(key, inner, mode=args.mode)))
+            report.explanations.append(
+                (
+                    source,
+                    lineno,
+                    explain_pair(key, inner, mode=settings.mode, entropy_threshold=settings.entropy_threshold),
+                )
+            )
 
         if args.audit:
-            finding = audit_pair(key, inner, mode=args.mode)
+            finding = audit_pair(key, inner, mode=settings.mode, entropy_threshold=settings.entropy_threshold)
             if finding is not None:
                 report.findings.append((source, lineno, finding))
             if len(inner) > _MAX_DETECT_LENGTH and finding is None:
                 report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
             continue
 
-        redacted, unscanned = _redact_value(key, inner, args.mode, args.replacement)
+        redacted, unscanned = _redact_value(key, inner, settings, args.replacement)
         if unscanned:
             report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
         out.append(f"{prefix}{left}{separator}{leading}{quote}{redacted}{quote}")
@@ -283,7 +420,7 @@ def _process_lines(text: str, fmt: str, source: str, args: argparse.Namespace, r
     return out
 
 
-def _process_json(text: str, source: str, args: argparse.Namespace, report: _Report) -> list[str]:
+def _process_json(text: str, source: str, args: argparse.Namespace, settings: _Settings, report: _Report) -> list[str]:
     """Redact a JSON document by walking the parsed structure."""
     try:
         data = json.loads(text)
@@ -291,34 +428,123 @@ def _process_json(text: str, source: str, args: argparse.Namespace, report: _Rep
         report.problem(source, exc.lineno, f"invalid JSON ({exc.msg}); nothing printed")
         return []
 
+    rules = settings.config.show or settings.config.hide
+
     if args.explain:
-        for explanation in explain_dict(data, mode=args.mode):
-            report.explanations.append((source, 0, explanation))
+        for explanation in explain_dict(data, mode=settings.mode, entropy_threshold=settings.entropy_threshold):
+            rule = _rule_for(explanation.key, settings.config) if rules else None
+            resolved = _rule_explanation(explanation.key, *rule) if rule else explanation
+            report.explanations.append((source, 0, resolved))
 
     if args.audit:
-        for finding in audit_dict(data, mode=args.mode):
+        for finding in audit_dict(data, mode=settings.mode, entropy_threshold=settings.entropy_threshold):
+            # Match on the rule kind, not on the entry spelling: matching is
+            # case-insensitive everywhere else, and an --audit that reported a
+            # key the redact pass prints would disagree with itself.
+            rule = _rule_for(finding.key, settings.config) if rules else None
+            if rule is not None and rule[0] == "show":
+                continue
             report.findings.append((source, 0, finding))
+        if rules:
+            for key in _hidden_keys(data, settings.config):
+                report.findings.append((source, 0, _rule_finding(key, settings.config.hides(key) or "")))
         return []
 
-    redacted = redact_dict(data, mode=args.mode, replacement=args.replacement)
+    redacted = redact_dict(
+        data, mode=settings.mode, replacement=args.replacement, entropy_threshold=settings.entropy_threshold
+    )
+    if rules:
+        redacted = _apply_rules_to_structure(data, redacted, settings.config, args.replacement)
     return json.dumps(redacted, indent=2).splitlines()
 
 
-def _process_dsn(text: str, source: str, args: argparse.Namespace, report: _Report) -> list[str]:
+def _apply_rules_to_structure(
+    original: object, redacted: object, config: Config, replacement: str, _depth: int = 0
+) -> object:
+    """Overlay config rules onto an already-redacted structure.
+
+    Walks the original and the redacted copy together: a hide rule replaces the
+    value, a show rule restores the original, and everything else keeps what
+    detection decided. Working from redact_dict's output rather than
+    reimplementing it keeps partial URL redaction and the depth caps intact.
+    """
+    if _depth >= _JSON_RULE_MAX_DEPTH:
+        return redacted
+
+    if isinstance(original, dict) and isinstance(redacted, dict):
+        result: dict[object, object] = {}
+        for key, value in original.items():
+            key_str = str(key)
+            current = redacted.get(key)
+            rule = _rule_for(key_str, config)
+            if rule is not None and isinstance(value, str):
+                result[key] = replacement if rule[0] == "hide" else value
+            elif isinstance(value, (dict, list)):
+                result[key] = _apply_rules_to_structure(value, current, config, replacement, _depth + 1)
+            else:
+                result[key] = current
+        return result
+
+    if isinstance(original, list) and isinstance(redacted, list) and len(original) == len(redacted):
+        return [
+            _apply_rules_to_structure(item, redacted[i], config, replacement, _depth + 1)
+            for i, item in enumerate(original)
+        ]
+
+    return redacted
+
+
+def _hidden_keys(data: object, config: Config, _depth: int = 0) -> list[str]:
+    """Keys a hide rule covers, so --audit reports them as findings."""
+    if _depth >= _JSON_RULE_MAX_DEPTH:
+        return []
+    found: list[str] = []
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if isinstance(value, str) and config.hides(str(key)) is not None:
+                found.append(str(key))
+            elif isinstance(value, (dict, list)):
+                found.extend(_hidden_keys(value, config, _depth + 1))
+    elif isinstance(data, list):
+        for item in data:
+            found.extend(_hidden_keys(item, config, _depth + 1))
+    return found
+
+
+def _process_dsn(text: str, source: str, args: argparse.Namespace, settings: _Settings, report: _Report) -> list[str]:
     """Redact bare connection strings, one per line."""
     out: list[str] = []
     for lineno, raw in enumerate(text.splitlines(), 1):
         if not raw.strip():
             out.append(raw)
             continue
+
+        rule = _rule_for("dsn", settings.config)
+        if rule is not None:
+            kind, name = rule
+            if args.explain:
+                report.explanations.append((source, lineno, _rule_explanation("dsn", kind, name)))
+            if args.audit:
+                if kind == "hide":
+                    report.findings.append((source, lineno, _rule_finding("dsn", name)))
+                continue
+            out.append(args.replacement if kind == "hide" else raw.strip())
+            continue
+
         if args.explain:
-            report.explanations.append((source, lineno, explain_pair("dsn", raw.strip(), mode=args.mode)))
+            report.explanations.append(
+                (
+                    source,
+                    lineno,
+                    explain_pair("dsn", raw.strip(), mode=settings.mode, entropy_threshold=settings.entropy_threshold),
+                )
+            )
         if args.audit:
-            finding = audit_pair("dsn", raw.strip(), mode=args.mode)
+            finding = audit_pair("dsn", raw.strip(), mode=settings.mode, entropy_threshold=settings.entropy_threshold)
             if finding is not None:
                 report.findings.append((source, lineno, finding))
             continue
-        redacted, unscanned = _redact_value("dsn", raw.strip(), args.mode, args.replacement)
+        redacted, unscanned = _redact_value("dsn", raw.strip(), settings, args.replacement)
         if unscanned:
             report.problem(source, lineno, f"value exceeds the {_MAX_DETECT_LENGTH}-byte scan cap; not scanned")
         out.append(redacted)
@@ -372,13 +598,39 @@ def _print_explanations(report: _Report) -> None:
         print(f"  {prefix}{columns}  {explanation.reason}", file=sys.stderr)
 
 
+# Kept in the help rather than the README: the exit codes are what a script
+# author needs, and --audit's guarantee is what makes it safe to paste output
+# into a bug report. Neither is discoverable from the flag list alone.
+_EPILOG = """\
+examples:
+  secretscreen app.env                  redact and print, cat-like
+  docker exec app env | secretscreen    screen a running container's environment
+  grep -rn TOKEN . | secretscreen       grep's file:line: prefixes are stripped, then restored
+  secretscreen --audit config.json      report findings only; never prints a value
+  secretscreen --explain app.env        account for every value, including the untouched ones
+  secretscreen --show DEPLOY_KEY x.env  vouch for one key by exact name
+
+exit codes:
+  0  nothing to report
+  1  --audit found something
+  2  a line could not be parsed, a file could not be read, or a config is invalid
+
+--audit prints key names, layers, and reasons — never a value, in either mode.
+--explain does the same for values that were left alone.
+
+Best-effort defense-in-depth, not a security boundary. Lines that cannot be
+structurally parsed are redacted and reported on stderr; nothing unparsed
+reaches stdout verbatim."""
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="secretscreen",
         description="Redact secrets from config-shaped data and print the result.",
-        epilog="Best-effort defense-in-depth, not a security boundary. "
-        "Lines that cannot be structurally parsed are redacted and reported on stderr.",
+        epilog=_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("files", nargs="*", metavar="FILE", help="files to redact; reads stdin when omitted or '-'")
     parser.add_argument("--audit", action="store_true", help="report findings without values; exit 1 if any are found")
     parser.add_argument("--format", choices=FORMATS, default="auto", help="input format (default: auto-detect)")
@@ -389,6 +641,26 @@ def _build_parser() -> argparse.ArgumentParser:
         help="report on stderr what happened to every value and why, including the ones left alone",
     )
     parser.add_argument("--replacement", default=REDACTED, help=f"replacement text (default: {REDACTED})")
+    parser.add_argument(
+        "--show",
+        action="append",
+        metavar="KEY",
+        help="never redact this key; exact name, no wildcards. Repeatable.",
+    )
+    parser.add_argument(
+        "--hide",
+        action="append",
+        metavar="GLOB",
+        help="always redact keys matching this glob. Repeatable.",
+    )
+    parser.add_argument("--entropy-threshold", type=float, metavar="N", help="entropy cutoff (default: 4.5)")
+    parser.add_argument("--config", metavar="FILE", help="use this config file and skip discovery")
+    parser.add_argument("--no-config", action="store_true", help="ignore all config files")
+    parser.add_argument(
+        "--trust-config",
+        action="store_true",
+        help="honour show entries from discovered project configs (they are ignored by default)",
+    )
     return parser
 
 
@@ -396,7 +668,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Entry point. Returns the process exit code."""
     parser = _build_parser()
     args = parser.parse_args(argv)
-    args.mode = Mode.AGGRESSIVE if args.aggressive else Mode.NORMAL
+    # None rather than NORMAL: config may set the mode, and only an explicit
+    # flag should override it.
+    args.mode = Mode.AGGRESSIVE if args.aggressive else None
 
     report = _Report()
     sources = args.files or ["-"]
@@ -407,15 +681,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if text is None:
             continue
 
+        try:
+            settings = _resolve_settings(None if path == "-" else path, args, report)
+        except ConfigError as exc:
+            # Fatal rather than skipped: continuing would screen this input with
+            # rules the user believes are in force and are not.
+            print(f"secretscreen: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+
         label = "<stdin>" if path == "-" else path
         fmt = args.format if args.format != "auto" else _detect_format(text, None if path == "-" else path)
 
         if fmt == "json":
-            lines.extend(_process_json(text, label, args, report))
+            lines.extend(_process_json(text, label, args, settings, report))
         elif fmt == "dsn":
-            lines.extend(_process_dsn(text, label, args, report))
+            lines.extend(_process_dsn(text, label, args, settings, report))
         else:
-            lines.extend(_process_lines(text, fmt, label, args, report))
+            lines.extend(_process_lines(text, fmt, label, args, settings, report))
 
     if args.audit:
         for source, lineno, finding in report.findings:

--- a/src/secretscreen/_config.py
+++ b/src/secretscreen/_config.py
@@ -1,0 +1,272 @@
+"""Configuration file loading, discovery, and merging.
+
+Config exists to stop the same false positive being re-diagnosed every run.
+It cannot do the same for false negatives — a missed secret leaves no trace to
+configure against — which is why ``--explain`` came first and why the rules
+here lean asymmetric:
+
+- ``hide`` accepts globs. Over-redaction is visible and harmless.
+- ``show`` does not. ``show = ["*_KEY"]`` would print ``AWS_SECRET_ACCESS_KEY``,
+  and it would go on matching keys nobody has written yet. Every entry is a
+  credential someone is choosing to print, so every entry gets named in full.
+
+``hide`` always beats ``show``, at every scope. A narrower rule that could
+un-hide something would be the one setting where being more specific makes the
+tool quieter, and that is not a direction worth supporting.
+
+Files are read, never written; nothing here creates or edits a config.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import tomllib
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+CONFIG_BASENAME = ".secretscreen.toml"
+USER_CONFIG_BASENAME = "secretscreen.toml"
+
+_WILDCARD_CHARACTERS = "*?["
+
+_TOP_LEVEL_KEYS = frozenset({"show", "hide", "root", "detection", "files"})
+_DETECTION_KEYS = frozenset({"mode", "entropy_threshold"})
+_FILE_SECTION_KEYS = frozenset({"show", "hide"})
+_MODES = frozenset({"normal", "aggressive"})
+
+
+class ConfigError(Exception):
+    """A config file is unreadable, malformed, or asks for something unsafe.
+
+    Always fatal. A typo that silently disabled a ``hide`` rule would leave the
+    user believing they had configured something they had not.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class Config:
+    """Resolved settings from one file, or several merged together."""
+
+    show: tuple[str, ...] = ()
+    hide: tuple[str, ...] = ()
+    mode: str | None = None
+    entropy_threshold: float | None = None
+    root: bool = False
+    files: tuple[tuple[str, Config], ...] = ()
+    sources: tuple[str, ...] = field(default=())
+
+    def for_file(self, basename: str) -> Config:
+        """Apply any ``[files."<basename>"]`` section for this input."""
+        lowered = basename.lower()
+        result = self
+        for name, section in self.files:
+            if name.lower() == lowered:
+                result = merge(result, section)
+        return result
+
+    def shows(self, key: str) -> str | None:
+        """Return the matching show entry, or None. Exact, case-insensitive."""
+        lowered = key.lower()
+        for entry in self.show:
+            if entry.lower() == lowered:
+                return entry
+        return None
+
+    def hides(self, key: str) -> str | None:
+        """Return the matching hide pattern, or None. Glob, case-insensitive."""
+        lowered = key.lower()
+        for pattern in self.hide:
+            if fnmatch.fnmatch(lowered, pattern.lower()):
+                return pattern
+        return None
+
+
+def merge(base: Config, overlay: Config) -> Config:
+    """Combine two configs. Lists union, scalars last-wins.
+
+    Union rather than replacement so a narrower config extends the broader one
+    instead of silently discarding it — the mistake ``safe_suffixes`` makes in
+    the library API, where passing one suffix drops the other twenty.
+    """
+    return Config(
+        show=_union(base.show, overlay.show),
+        hide=_union(base.hide, overlay.hide),
+        mode=overlay.mode if overlay.mode is not None else base.mode,
+        entropy_threshold=(
+            overlay.entropy_threshold if overlay.entropy_threshold is not None else base.entropy_threshold
+        ),
+        root=overlay.root or base.root,
+        files=base.files + overlay.files,
+        sources=_union(base.sources, overlay.sources),
+    )
+
+
+def check_show_entries(entries: tuple[str, ...], label: str) -> None:
+    """Reject wildcards in show entries. Raises ConfigError.
+
+    Shared by the file loader and ``--show`` so the flag cannot do what the
+    file is forbidden to. An unenforced ``--show '*_KEY'`` would not even fail
+    loudly — exact matching makes it a silent no-op, which reads as a rule
+    that is in force when it never fired once.
+    """
+    offenders = [entry for entry in entries if any(char in entry for char in _WILDCARD_CHARACTERS)]
+    if offenders:
+        raise ConfigError(
+            f"{label} must name keys exactly — {', '.join(repr(o) for o in offenders)} "
+            f"contains a wildcard. A pattern would also match keys that do not exist yet, "
+            f"and every show entry is a value chosen to be printed."
+        )
+
+
+def without_show(config: Config) -> Config:
+    """Drop every show entry, including inside file sections.
+
+    Applied to configs that were merely found on disk rather than written by
+    the person running the command. A discovered file may make the tool more
+    paranoid; letting it make the tool quieter would mean a repository could
+    decide which of your credentials get printed.
+    """
+    if not config.show and not any(section.show for _, section in config.files):
+        return config
+    stripped_files = tuple((name, replace(section, show=())) for name, section in config.files)
+    return replace(config, show=(), files=stripped_files)
+
+
+def _union(first: tuple[str, ...], second: tuple[str, ...]) -> tuple[str, ...]:
+    """Concatenate, preserving order and dropping duplicates."""
+    return tuple(dict.fromkeys(first + second))
+
+
+def load(path: Path) -> Config:
+    """Read and validate one config file. Raises ConfigError on any problem."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ConfigError(f"{path}: cannot read: {exc}") from exc
+
+    try:
+        data = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as exc:
+        raise ConfigError(f"{path}: invalid TOML: {exc}") from exc
+
+    return _from_mapping(data, str(path))
+
+
+def _from_mapping(data: dict[str, object], source: str) -> Config:
+    _reject_unknown(data, _TOP_LEVEL_KEYS, source, "")
+
+    detection = data.get("detection", {})
+    if not isinstance(detection, dict):
+        raise ConfigError(f"{source}: [detection] must be a table")
+    _reject_unknown(detection, _DETECTION_KEYS, source, "detection.")
+
+    mode = detection.get("mode")
+    if mode is not None:
+        if not isinstance(mode, str) or mode not in _MODES:
+            raise ConfigError(f"{source}: detection.mode must be one of {sorted(_MODES)}")
+
+    threshold = detection.get("entropy_threshold")
+    if threshold is not None:
+        if isinstance(threshold, bool) or not isinstance(threshold, (int, float)):
+            raise ConfigError(f"{source}: detection.entropy_threshold must be a number")
+        threshold = float(threshold)
+
+    root = data.get("root", False)
+    if not isinstance(root, bool):
+        raise ConfigError(f"{source}: root must be true or false")
+
+    files_table = data.get("files", {})
+    if not isinstance(files_table, dict):
+        raise ConfigError(f"{source}: [files] must be a table of file names")
+
+    sections: list[tuple[str, Config]] = []
+    for name, section in files_table.items():
+        if not isinstance(section, dict):
+            raise ConfigError(f'{source}: [files."{name}"] must be a table')
+        _reject_unknown(section, _FILE_SECTION_KEYS, source, f'files."{name}".')
+        sections.append(
+            (
+                name,
+                Config(
+                    show=_string_list(section.get("show"), source, f'files."{name}".show', allow_wildcards=False),
+                    hide=_string_list(section.get("hide"), source, f'files."{name}".hide', allow_wildcards=True),
+                ),
+            )
+        )
+
+    return Config(
+        show=_string_list(data.get("show"), source, "show", allow_wildcards=False),
+        hide=_string_list(data.get("hide"), source, "hide", allow_wildcards=True),
+        mode=mode,
+        entropy_threshold=threshold,
+        root=root,
+        files=tuple(sections),
+        sources=(source,),
+    )
+
+
+def _reject_unknown(table: dict[str, object], allowed: frozenset[str], source: str, prefix: str) -> None:
+    """A misspelled key must fail loudly rather than be quietly ignored."""
+    unknown = sorted(set(table) - allowed)
+    if unknown:
+        names = ", ".join(f"{prefix}{name}" for name in unknown)
+        raise ConfigError(f"{source}: unknown setting(s): {names}")
+
+
+def _string_list(value: object, source: str, name: str, *, allow_wildcards: bool) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ConfigError(f"{source}: {name} must be a list of strings")
+    entries = tuple(value)
+
+    if not allow_wildcards:
+        check_show_entries(entries, f"{source}: {name}")
+    return entries
+
+
+def user_config_path() -> Path:
+    """Location of the user's own config, honouring XDG_CONFIG_HOME."""
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base) if base else Path.home() / ".config"
+    return root / USER_CONFIG_BASENAME
+
+
+def discover(start: Path, *, stop_at: Path | None = None) -> list[Path]:
+    """Find project configs from `start` upward, nearest last.
+
+    Nearest last so the caller can fold them in order and let the closest file
+    win. The walk stops at the home directory, at a filesystem root, or at the
+    first config declaring ``root = true``.
+    """
+    boundary = stop_at if stop_at is not None else Path.home()
+    found: list[Path] = []
+
+    current = start.resolve() if start.exists() else start.absolute()
+    seen: set[Path] = set()
+    while current not in seen:
+        seen.add(current)
+        candidate = current / CONFIG_BASENAME
+        if candidate.is_file():
+            found.append(candidate)
+            if _declares_root(candidate):
+                break
+        if current == boundary or current == current.parent:
+            break
+        current = current.parent
+
+    found.reverse()
+    return found
+
+
+def _declares_root(path: Path) -> bool:
+    """Check the root flag without failing the walk on a broken file.
+
+    A malformed config still has to be reported, but that happens when it is
+    loaded. Here a read failure simply means the walk continues.
+    """
+    try:
+        return bool(tomllib.loads(path.read_text(encoding="utf-8")).get("root", False))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return False

--- a/src/secretscreen/_config.py
+++ b/src/secretscreen/_config.py
@@ -193,8 +193,8 @@ def _union(first: tuple[str, ...], second: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(first + second))
 
 
-def load(path: Path) -> Config:
-    """Read and validate one config file. Raises ConfigError on any problem."""
+def _read_toml(path: Path) -> dict[str, object]:
+    """Read and parse one config file. Raises ConfigError on any problem."""
     try:
         if path.is_file() and path.stat().st_size > MAX_CONFIG_BYTES:
             raise ConfigError(f"{path}: larger than {MAX_CONFIG_BYTES} bytes; not a config file")
@@ -203,7 +203,7 @@ def load(path: Path) -> Config:
         raise ConfigError(f"{path}: cannot read: {exc}") from exc
 
     try:
-        data = tomllib.loads(raw)
+        return tomllib.loads(raw)
     except tomllib.TOMLDecodeError as exc:
         raise ConfigError(f"{path}: invalid TOML: {exc}") from exc
     except RecursionError as exc:
@@ -212,7 +212,78 @@ def load(path: Path) -> Config:
         # error handling — and exit 1 reads as "--audit found something".
         raise ConfigError(f"{path}: nested too deeply to parse") from exc
 
-    return _from_mapping(data, str(path))
+
+class Loader:
+    """Reads each config file once for the run that owns it.
+
+    Discovery happens per input file, and the root check needs the same file
+    the loader is about to parse — so the naive arrangement read every config
+    twice per input, and re-walked the same directories for each. Fifty files
+    in a twelve-deep tree came to some twelve hundred reads of a handful of
+    files.
+
+    Scoped to one run rather than kept module-level: a config edited between
+    two invocations has to be seen, and a cache nobody can invalidate is how
+    that stops being true.
+    """
+
+    def __init__(self) -> None:
+        self._parsed: dict[str, dict[str, object]] = {}
+        self._walks: dict[tuple[str, str, bool], list[Path]] = {}
+
+    def load(self, path: Path) -> Config:
+        """Read and validate one config file. Raises ConfigError on any problem."""
+        return _from_mapping(self._raw(path), str(path))
+
+    def discover(self, start: Path, *, stop_at: Path | None = None, honour_root: bool = True) -> list[Path]:
+        """Find project configs from `start` upward, nearest last."""
+        current = start.resolve() if start.exists() else start.absolute()
+        key = (str(current), str(stop_at), honour_root)
+        if key not in self._walks:
+            self._walks[key] = self._walk(current, stop_at, honour_root)
+        return self._walks[key]
+
+    def _raw(self, path: Path) -> dict[str, object]:
+        key = str(path)
+        if key not in self._parsed:
+            self._parsed[key] = _read_toml(path)
+        return self._parsed[key]
+
+    def _declares_root(self, path: Path) -> bool:
+        """Check the root flag without failing the walk on a broken file.
+
+        A malformed config still has to be reported, but that happens when it
+        is loaded. Here a read failure simply means the walk continues.
+        """
+        try:
+            return bool(self._raw(path).get("root", False))
+        except ConfigError:
+            return False
+
+    def _walk(self, start: Path, stop_at: Path | None, honour_root: bool) -> list[Path]:
+        boundary = stop_at if stop_at is not None else Path.home()
+        found: list[Path] = []
+
+        current = start
+        seen: set[Path] = set()
+        while current not in seen:
+            seen.add(current)
+            candidate = current / CONFIG_BASENAME
+            if candidate.is_file():
+                found.append(candidate)
+                if honour_root and self._declares_root(candidate):
+                    break
+            if current == boundary or current == current.parent:
+                break
+            current = current.parent
+
+        found.reverse()
+        return found
+
+
+def load(path: Path) -> Config:
+    """Read and validate one config file. Raises ConfigError on any problem."""
+    return Loader().load(path)
 
 
 def _from_mapping(data: dict[str, object], source: str) -> Config:
@@ -307,33 +378,4 @@ def discover(start: Path, *, stop_at: Path | None = None, honour_root: bool = Tr
     own to strand the reader's: it ends the walk before their own config one
     level up is ever read, and the output looks the same either way.
     """
-    boundary = stop_at if stop_at is not None else Path.home()
-    found: list[Path] = []
-
-    current = start.resolve() if start.exists() else start.absolute()
-    seen: set[Path] = set()
-    while current not in seen:
-        seen.add(current)
-        candidate = current / CONFIG_BASENAME
-        if candidate.is_file():
-            found.append(candidate)
-            if honour_root and _declares_root(candidate):
-                break
-        if current == boundary or current == current.parent:
-            break
-        current = current.parent
-
-    found.reverse()
-    return found
-
-
-def _declares_root(path: Path) -> bool:
-    """Check the root flag without failing the walk on a broken file.
-
-    A malformed config still has to be reported, but that happens when it is
-    loaded. Here a read failure simply means the walk continues.
-    """
-    try:
-        return bool(tomllib.loads(path.read_text(encoding="utf-8")).get("root", False))
-    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, RecursionError):
-        return False
+    return Loader().discover(start, stop_at=stop_at, honour_root=honour_root)

--- a/src/secretscreen/_config.py
+++ b/src/secretscreen/_config.py
@@ -28,6 +28,14 @@ from pathlib import Path
 CONFIG_BASENAME = ".secretscreen.toml"
 USER_CONFIG_BASENAME = "secretscreen.toml"
 
+# Mirrors the library default. Needed here to bound what a discovered config
+# may do to the threshold when there is no other value to compare against.
+DEFAULT_ENTROPY_THRESHOLD = 4.5
+
+# A config file is a short list of key names. Anything larger is not one, and
+# reading it is how a planted file becomes a denial of service.
+MAX_CONFIG_BYTES = 256 * 1024
+
 _WILDCARD_CHARACTERS = "*?["
 
 _TOP_LEVEL_KEYS = frozenset({"show", "hide", "root", "detection", "files"})
@@ -57,13 +65,24 @@ class Config:
     sources: tuple[str, ...] = field(default=())
 
     def for_file(self, basename: str) -> Config:
-        """Apply any ``[files."<basename>"]`` section for this input."""
+        """Apply any ``[files."<basename>"]`` section for this input.
+
+        Section names glob. A name is a scoping selector, not a rule: matching
+        more files cannot grant a section anything a top-level entry does not
+        already have, and matching literally meant ``[files."*.env"]`` loaded
+        without complaint and never fired once.
+        """
         lowered = basename.lower()
         result = self
         for name, section in self.files:
-            if name.lower() == lowered:
+            if fnmatch.fnmatch(lowered, name.lower()):
                 result = merge(result, section)
         return result
+
+    @property
+    def has_rules(self) -> bool:
+        """Whether any show or hide entry is in force."""
+        return bool(self.show or self.hide)
 
     def shows(self, key: str) -> str | None:
         """Return the matching show entry, or None. Exact, case-insensitive."""
@@ -119,18 +138,54 @@ def check_show_entries(entries: tuple[str, ...], label: str) -> None:
         )
 
 
-def without_show(config: Config) -> Config:
-    """Drop every show entry, including inside file sections.
+def merge_tightening(base: Config, overlay: Config) -> Config:
+    """Merge a config that was found on disk rather than written by the caller.
 
-    Applied to configs that were merely found on disk rather than written by
-    the person running the command. A discovered file may make the tool more
-    paranoid; letting it make the tool quieter would mean a repository could
-    decide which of your credentials get printed.
+    A discovered file may make the tool more paranoid and nothing else. It can
+    arrive with a repository cloned five minutes ago, or be planted in a shared
+    directory by anyone with write access there, so every setting it carries is
+    read as a request to tighten:
+
+    - ``hide`` merges normally. Over-redaction is visible and harmless.
+    - ``show`` is dropped. It is the one setting that prints a credential.
+    - ``mode`` may only go up, normal to aggressive, never back down.
+    - ``entropy_threshold`` may only fall. A lower cutoff catches more.
+    - ``root`` is ignored; truncating the walk drops other files' hide rules,
+      which is loosening by omission.
+
+    Stripping only ``show`` was the original mistake: the three settings that
+    quietly stop a secret being *found* are as good as the one that prints it.
     """
-    if not config.show and not any(section.show for _, section in config.files):
-        return config
-    stripped_files = tuple((name, replace(section, show=())) for name, section in config.files)
-    return replace(config, show=(), files=stripped_files)
+    show_free = (
+        replace(overlay, show=(), files=tuple((name, replace(s, show=())) for name, s in overlay.files))
+        if overlay.show or any(s.show for _, s in overlay.files)
+        else overlay
+    )
+    tightened = replace(
+        show_free,
+        mode="aggressive" if "aggressive" in (base.mode, overlay.mode) else base.mode,
+        entropy_threshold=_lower_threshold(base.entropy_threshold, overlay.entropy_threshold),
+        root=base.root,
+    )
+    return merge(base, tightened)
+
+
+def _lower_threshold(base: float | None, overlay: float | None) -> float | None:
+    """The stricter of two entropy cutoffs, bounded by the default.
+
+    Bounded because a discovered file is otherwise free to raise the cutoff
+    out of reach when nothing else set one — 99.0 turns layer 5 off without
+    ever naming a key.
+    """
+    if overlay is None:
+        return base
+    ceiling = base if base is not None else DEFAULT_ENTROPY_THRESHOLD
+    return min(ceiling, overlay)
+
+
+def drops_show(config: Config) -> bool:
+    """Whether this config carries show entries anywhere, including sections."""
+    return bool(config.show) or any(section.show for _, section in config.files)
 
 
 def _union(first: tuple[str, ...], second: tuple[str, ...]) -> tuple[str, ...]:
@@ -141,6 +196,8 @@ def _union(first: tuple[str, ...], second: tuple[str, ...]) -> tuple[str, ...]:
 def load(path: Path) -> Config:
     """Read and validate one config file. Raises ConfigError on any problem."""
     try:
+        if path.is_file() and path.stat().st_size > MAX_CONFIG_BYTES:
+            raise ConfigError(f"{path}: larger than {MAX_CONFIG_BYTES} bytes; not a config file")
         raw = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         raise ConfigError(f"{path}: cannot read: {exc}") from exc
@@ -149,6 +206,11 @@ def load(path: Path) -> Config:
         data = tomllib.loads(raw)
     except tomllib.TOMLDecodeError as exc:
         raise ConfigError(f"{path}: invalid TOML: {exc}") from exc
+    except RecursionError as exc:
+        # tomllib recurses per nesting level, so a file of nothing but open
+        # brackets exits through the interpreter rather than through our own
+        # error handling — and exit 1 reads as "--audit found something".
+        raise ConfigError(f"{path}: nested too deeply to parse") from exc
 
     return _from_mapping(data, str(path))
 
@@ -233,12 +295,17 @@ def user_config_path() -> Path:
     return root / USER_CONFIG_BASENAME
 
 
-def discover(start: Path, *, stop_at: Path | None = None) -> list[Path]:
+def discover(start: Path, *, stop_at: Path | None = None, honour_root: bool = True) -> list[Path]:
     """Find project configs from `start` upward, nearest last.
 
     Nearest last so the caller can fold them in order and let the closest file
     win. The walk stops at the home directory, at a filesystem root, or at the
     first config declaring ``root = true``.
+
+    ``honour_root`` is False when the files being walked are not trusted. A
+    ``root = true`` in a directory anyone can write to needs no rules of its
+    own to strand the reader's: it ends the walk before their own config one
+    level up is ever read, and the output looks the same either way.
     """
     boundary = stop_at if stop_at is not None else Path.home()
     found: list[Path] = []
@@ -250,7 +317,7 @@ def discover(start: Path, *, stop_at: Path | None = None) -> list[Path]:
         candidate = current / CONFIG_BASENAME
         if candidate.is_file():
             found.append(candidate)
-            if _declares_root(candidate):
+            if honour_root and _declares_root(candidate):
                 break
         if current == boundary or current == current.parent:
             break
@@ -268,5 +335,5 @@ def _declares_root(path: Path) -> bool:
     """
     try:
         return bool(tomllib.loads(path.read_text(encoding="utf-8")).get("root", False))
-    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, RecursionError):
         return False

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -6,7 +6,7 @@ Public API: redact_pair, redact_dict, audit_pair, audit_dict.
 from __future__ import annotations
 
 import enum
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from secretscreen._entropy import MIN_ENTROPY_LENGTH, looks_like_secret, shannon_entropy
 from secretscreen._formats import matches_known_format
@@ -429,12 +429,20 @@ STATE_UNSCANNED = "unscanned"
 
 @dataclass(frozen=True, slots=True)
 class Explanation:
-    """Why one key-value pair was or was not redacted. Never holds the value."""
+    """Why one key-value pair was or was not redacted. Never holds the value.
+
+    ``key`` is for reading — inside a structure it is a path such as
+    ``services[0].db.password``. ``name`` is the plain key that path ends at,
+    which is what a caller matches rules against. Keeping both apart matters:
+    matching a rule against the path is how an account of what happened ends
+    up disagreeing with what was printed.
+    """
 
     key: str
     state: str
     layer: str
     reason: str
+    name: str = ""
 
 
 def _vetoed_by_safe_suffix(key: str, config: ScreenConfig) -> tuple[str, str] | None:
@@ -567,8 +575,14 @@ def _explain_recursive(
     explanations: list[Explanation],
     _depth: int = 0,
     _prefix: str = "",
+    _name: str = "",
 ) -> None:
-    """Walk a structure, accounting for every string value it contains."""
+    """Walk a structure, accounting for every string value it contains.
+
+    Two keys are carried down, not one: the display path, and the plain key
+    it ends at. A list element inherits the name of the key its list belongs
+    to, the same key redaction screened it under.
+    """
     if _depth >= _MAX_RECURSIVE_DEPTH:
         # "Accounts for every value" has to include the ones the cap stopped
         # it reaching. Returning quietly is the failure --explain exists for.
@@ -579,17 +593,17 @@ def _explain_recursive(
         for k, v in data.items():
             key_str = f"{_prefix}.{k}" if _prefix else str(k)
             if isinstance(v, str):
-                explanations.append(_explain(key_str, v, config))
+                explanations.append(replace(_explain(key_str, v, config), name=str(k)))
             elif isinstance(v, (dict, list)):
-                _explain_recursive(v, config, explanations, _depth + 1, key_str)
+                _explain_recursive(v, config, explanations, _depth + 1, key_str, str(k))
 
     elif isinstance(data, list):
         for i, item in enumerate(data):
             key_str = f"{_prefix}[{i}]"
             if isinstance(item, str):
-                explanations.append(_explain(key_str, item, config))
+                explanations.append(replace(_explain(key_str, item, config), name=_name))
             elif isinstance(item, (dict, list)):
-                _explain_recursive(item, config, explanations, _depth + 1, key_str)
+                _explain_recursive(item, config, explanations, _depth + 1, key_str, _name)
 
 
 def _audit_recursive(

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -586,7 +586,7 @@ def _explain_recursive(
     if _depth >= _MAX_RECURSIVE_DEPTH:
         # "Accounts for every value" has to include the ones the cap stopped
         # it reaching. Returning quietly is the failure --explain exists for.
-        explanations.append(Explanation(_prefix, STATE_UNSCANNED, "", _TOO_DEEP))
+        explanations.append(Explanation(_prefix, STATE_UNSCANNED, "", _TOO_DEEP, name=_name))
         return
 
     if isinstance(data, dict):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import json
 
 import pytest
 
+from secretscreen import __version__
 from secretscreen._cli import EXIT_ERROR, EXIT_FINDINGS, EXIT_OK, main
 
 SAMPLE_ENV = """\
@@ -93,6 +94,17 @@ class TestExplainLayout:
         assert lines, "expected an explanation naming the nested path"
         assert all(len(line) < 200 for line in lines), lines
         assert "…" in lines[0]
+
+
+class TestVersion:
+    """--version is how a user reports a bug against the right release."""
+
+    def test_prints_package_version_and_exits_clean(self, capsys) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            main(["--version"])
+
+        assert exit_info.value.code == EXIT_OK
+        assert capsys.readouterr().out.strip() == f"secretscreen {__version__}"
 
 
 class TestUnparseableInputFailsLoudly:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,8 @@ with a `show` rule would quietly pass tests that should fail.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from secretscreen._cli import EXIT_ERROR, EXIT_FINDINGS, EXIT_OK, main
@@ -588,6 +590,33 @@ class TestRulesInEveryMode:
         (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["dsn"]')
         main([_write(isolated, "d.txt", "postgres://u:p@h/db\n"), "--format", "dsn"])
         assert capsys.readouterr().out.strip() == "[REDACTED]"
+
+
+class TestEachConfigIsReadOnce:
+    """Discovery repeats per input; the reads behind it must not.
+
+    The root check and the load parsed the same file separately, and the walk
+    started again for every input. Fifty files in a twelve-deep tree came to
+    twelve hundred reads of twelve files.
+    """
+
+    def test_one_read_per_file_across_many_inputs(self, isolated, monkeypatch, capsys) -> None:
+        (isolated / ".secretscreen.toml").write_text('hide = ["LOG_*"]')
+        inputs = [_write(isolated, f"a{i}.env", "LOG_LEVEL=debug\n") for i in range(5)]
+
+        reads = []
+        original = Path.read_text
+
+        def counted(self, *args, **kwargs):
+            if self.name == ".secretscreen.toml":
+                reads.append(str(self))
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", counted)
+        main(inputs)
+
+        assert capsys.readouterr().out.count("[REDACTED]") == 5
+        assert len(reads) == 1, reads
 
 
 class TestConfigErrorsAreFatal:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,16 @@ from __future__ import annotations
 import pytest
 
 from secretscreen._cli import EXIT_ERROR, EXIT_FINDINGS, EXIT_OK, main
-from secretscreen._config import Config, ConfigError, discover, load, merge, user_config_path, without_show
+from secretscreen._config import (
+    Config,
+    ConfigError,
+    discover,
+    drops_show,
+    load,
+    merge,
+    merge_tightening,
+    user_config_path,
+)
 
 
 def _write(directory, name: str, content: str) -> str:
@@ -105,6 +114,30 @@ class TestLoading:
         with pytest.raises(ConfigError, match="cannot read"):
             load(tmp_path / "missing.toml")
 
+    def test_nesting_that_exhausts_the_parser_is_an_error_not_a_crash(self, tmp_path) -> None:
+        """tomllib raises RecursionError, which exits 1 — the code for findings."""
+        path = tmp_path / "c.toml"
+        path.write_text("a = " + "[" * 5000 + "]" * 5000)
+
+        with pytest.raises(ConfigError, match="nested too deeply"):
+            load(path)
+
+    def test_oversized_file_is_refused_before_it_is_read(self, tmp_path) -> None:
+        path = tmp_path / "c.toml"
+        path.write_text('hide = ["X"]\n# ' + "padding " * 40_000)
+
+        with pytest.raises(ConfigError, match="not a config file"):
+            load(path)
+
+    def test_file_section_names_glob(self, tmp_path) -> None:
+        """`[files."*.env"]` used to load without complaint and never fire."""
+        path = tmp_path / "c.toml"
+        path.write_text('[files."*.env"]\nhide = ["DEPLOY_NOTE"]')
+        config = load(path)
+
+        assert config.for_file("app.env").hides("DEPLOY_NOTE") == "DEPLOY_NOTE"
+        assert config.for_file("app.json").hides("DEPLOY_NOTE") is None
+
 
 class TestMatching:
     """show is exact; hide is a glob. Both case-insensitive."""
@@ -143,14 +176,15 @@ class TestMerging:
     def test_union_drops_duplicates_and_keeps_order(self) -> None:
         assert merge(Config(show=("A", "B")), Config(show=("B", "C"))).show == ("A", "B", "C")
 
-    def test_without_show_strips_top_level_and_sections(self) -> None:
-        config = Config(show=("A",), hide=("X*",), files=(("f.env", Config(show=("B",), hide=("Y*",))),))
-        stripped = without_show(config)
+    def test_tightening_merge_strips_show_top_level_and_in_sections(self) -> None:
+        untrusted = Config(show=("A",), hide=("X*",), files=(("f.env", Config(show=("B",), hide=("Y*",))),))
+        merged = merge_tightening(Config(), untrusted)
 
-        assert stripped.show == ()
-        assert stripped.files[0][1].show == ()
-        assert stripped.hide == ("X*",)
-        assert stripped.files[0][1].hide == ("Y*",)
+        assert merged.show == ()
+        assert merged.files[0][1].show == ()
+        assert merged.hide == ("X*",)
+        assert merged.files[0][1].hide == ("Y*",)
+        assert drops_show(untrusted) is True
 
 
 class TestDiscovery:
@@ -299,6 +333,82 @@ class TestDiscoveredConfigsCannotLoosen:
         main([_write(stack, "a.env", "API_TOKEN=realsecret\n"), "--trust-config"])
         assert "API_TOKEN=realsecret" in capsys.readouterr().out
 
+    def test_project_config_cannot_raise_the_entropy_threshold(self, isolated, capsys) -> None:
+        """Turning a layer off is loosening, even though it names no key."""
+        (isolated / "xdg" / "secretscreen.toml").write_text('[detection]\nmode = "aggressive"')
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text("[detection]\nentropy_threshold = 99.0")
+        blob = "Zk9pQ3RYb1Jm7dQwLmA3ZcVbNxK2Ht4Ue8Sy1Gp0Ij6Rw"
+        main([_write(stack, "a.env", f"BLOB={blob}\n")])
+
+        assert blob not in capsys.readouterr().out
+
+    def test_project_config_cannot_lower_the_entropy_threshold_below_the_users(self, isolated, capsys) -> None:
+        """Tightening in the other direction is fine, and stays fine."""
+        (isolated / "xdg" / "secretscreen.toml").write_text('[detection]\nmode = "aggressive"')
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text("[detection]\nentropy_threshold = 1.0")
+        main([_write(stack, "a.env", "SHORTISH=abcdefghijklmnopqrstuvwx\n")])
+
+        assert "abcdefghijklmnopqrstuvwx" not in capsys.readouterr().out
+
+    def test_project_config_cannot_downgrade_the_mode(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('[detection]\nmode = "aggressive"')
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text('[detection]\nmode = "normal"')
+        blob = "Zk9pQ3RYb1Jm7dQwLmA3ZcVbNxK2Ht4Ue8Sy1Gp0Ij6Rw"
+        main([_write(stack, "a.env", f"BLOB={blob}\n")])
+
+        assert blob not in capsys.readouterr().out
+
+    def test_project_config_may_upgrade_the_mode(self, isolated, capsys) -> None:
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text('[detection]\nmode = "aggressive"')
+        blob = "Zk9pQ3RYb1Jm7dQwLmA3ZcVbNxK2Ht4Ue8Sy1Gp0Ij6Rw"
+        main([_write(stack, "a.env", f"BLOB={blob}\n")])
+
+        assert blob not in capsys.readouterr().out
+
+    def test_planted_root_cannot_strand_a_rule_from_further_up(self, isolated, capsys) -> None:
+        """`root = true` needs no rules of its own to delete someone else's.
+
+        It ends the walk before the config one level up is read, and the
+        output looks the same either way.
+        """
+        (isolated / ".secretscreen.toml").write_text('hide = ["DEPLOY_*"]')
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text("root = true")
+        main([_write(stack, "a.env", "DEPLOY_NOTE=hello\n")])
+        captured = capsys.readouterr()
+
+        assert "DEPLOY_NOTE=[REDACTED]" in captured.out
+        assert "root ignored" in captured.err
+
+    def test_trust_config_honours_root(self, isolated, capsys) -> None:
+        (isolated / ".secretscreen.toml").write_text('hide = ["DEPLOY_*"]')
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text("root = true")
+        main([_write(stack, "a.env", "DEPLOY_NOTE=hello\n"), "--trust-config"])
+
+        assert "DEPLOY_NOTE=hello" in capsys.readouterr().out
+
+    def test_a_show_entry_in_a_file_section_is_announced_too(self, isolated, capsys) -> None:
+        """Stripped silently is still stripped, but the user learns nothing."""
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text('[files."a.env"]\nshow = ["API_TOKEN"]')
+        main([_write(stack, "a.env", "API_TOKEN=realsecret\n")])
+        captured = capsys.readouterr()
+
+        assert "realsecret" not in captured.out
+        assert "show entries ignored" in captured.err
+
     def test_project_hide_always_applies(self, isolated, capsys) -> None:
         stack = isolated / "stack"
         stack.mkdir()
@@ -401,6 +511,73 @@ class TestRulesInEveryMode:
 
         assert code == EXIT_OK
         assert captured.out == ""
+
+    def test_explain_names_the_rule_that_hid_a_nested_key(self, isolated, capsys) -> None:
+        """Rules match the plain key; --explain displays a path. Never confuse them.
+
+        Matching `hide = ["region"]` against `services[0].db.region` fails, and
+        the account then says `clean` about a value stdout printed as
+        [REDACTED].
+        """
+        document = '{"services": [{"db": {"password": "hunter2", "region": "eu-west"}}]}'
+        main([_write(isolated, "a.json", document), "--no-config", "--hide", "region", "--explain"])
+        captured = capsys.readouterr()
+
+        assert '"region": "[REDACTED]"' in captured.out
+        assert "hide rule 'region'" in captured.err
+        assert "clean     services[0].db.region" not in captured.err
+
+    def test_explain_never_claims_a_redaction_a_show_rule_prevented(self, isolated, capsys) -> None:
+        """The direction that matters: stdout prints it, so the account must say so."""
+        document = '{"services": [{"db": {"password": "hunter2"}}]}'
+        main([_write(isolated, "a.json", document), "--no-config", "--show", "password", "--explain"])
+        captured = capsys.readouterr()
+
+        assert '"password": "hunter2"' in captured.out
+        assert "show rule 'password'" in captured.err
+        assert "redacted" not in captured.err
+
+    def test_audit_reports_a_key_once_when_a_rule_and_a_layer_both_flag_it(self, isolated, capsys) -> None:
+        """A hide rule on a key detection also catches is one finding, not two."""
+        document = '{"password": "hunter2"}'
+        code = main([_write(isolated, "a.json", document), "--no-config", "--audit", "--hide", "password"])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_FINDINGS
+        assert len(out.strip().splitlines()) == 1
+
+    def test_hide_covers_an_object_and_everything_in_it(self, isolated, capsys) -> None:
+        """Redacting only the leaves would leave the subtree's shape on display."""
+        document = '{"creds": {"note": "plaintext", "seat": "12"}}'
+        main([_write(isolated, "a.json", document), "--no-config", "--hide", "creds", "--explain"])
+        captured = capsys.readouterr()
+
+        assert '"creds": "[REDACTED]"' in captured.out
+        assert "plaintext" not in captured.out
+        assert "note" not in captured.out
+        assert captured.err.count("hide rule 'creds'") == 2  # the account still covers both leaves
+
+    def test_hide_covers_a_value_that_is_not_a_string(self, isolated, capsys) -> None:
+        main([_write(isolated, "a.json", '{"port": 5432}'), "--no-config", "--hide", "port"])
+        assert '"port": "[REDACTED]"' in capsys.readouterr().out
+
+    def test_show_refuses_a_value_that_is_not_a_string_and_says_so(self, isolated, capsys) -> None:
+        """Vouching for a subtree vouches for values nobody has added yet."""
+        document = '{"creds": {"note": "plaintext"}}'
+        code = main([_write(isolated, "a.json", document), "--no-config", "--show", "creds"])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_OK
+        assert "names a value that is not a string; ignored" in captured.err
+
+    def test_audit_reports_a_hidden_object_once(self, isolated, capsys) -> None:
+        document = '{"creds": {"note": "plaintext", "seat": "12"}}'
+        code = main([_write(isolated, "a.json", document), "--no-config", "--audit", "--hide", "creds"])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_FINDINGS
+        assert len(out.strip().splitlines()) == 1
+        assert "note" not in out
 
     def test_json_explain_reports_rules(self, isolated, capsys) -> None:
         (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["host"]')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,436 @@
+"""Tests for config files, discovery, and the show/hide rules.
+
+Config exists to stop the same false positive being re-diagnosed every run. It
+cannot do the same for a false negative, which leaves no trace to configure
+against — so the rules here are deliberately asymmetric, and most of these
+tests are about the asymmetry holding rather than about loading TOML.
+
+Every CLI test pins XDG_CONFIG_HOME at a temporary directory. Without that the
+suite would read whatever config the developer happens to have, and a machine
+with a `show` rule would quietly pass tests that should fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from secretscreen._cli import EXIT_ERROR, EXIT_FINDINGS, EXIT_OK, main
+from secretscreen._config import Config, ConfigError, discover, load, merge, user_config_path, without_show
+
+
+def _write(directory, name: str, content: str) -> str:
+    path = directory / name
+    path.write_text(content)
+    return str(path)
+
+
+@pytest.fixture
+def isolated(tmp_path, monkeypatch):
+    """A config-free environment: no user config, no inherited rules."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    (tmp_path / "xdg").mkdir()
+    return tmp_path
+
+
+class TestLoading:
+    """Parsing and validation of a single file."""
+
+    def test_full_file(self, tmp_path) -> None:
+        path = tmp_path / "c.toml"
+        path.write_text(
+            'show = ["DEPLOY_PUBLIC_KEY"]\n'
+            'hide = ["*_NOTIFICATION_URL"]\n'
+            "root = true\n"
+            "[detection]\n"
+            'mode = "aggressive"\n'
+            "entropy_threshold = 4.2\n"
+            '[files."demo.env"]\n'
+            'show = ["API_TOKEN"]\n'
+        )
+        config = load(path)
+
+        assert config.show == ("DEPLOY_PUBLIC_KEY",)
+        assert config.hide == ("*_NOTIFICATION_URL",)
+        assert config.root is True
+        assert config.mode == "aggressive"
+        assert config.entropy_threshold == 4.2
+        assert config.files[0][0] == "demo.env"
+        assert config.files[0][1].show == ("API_TOKEN",)
+
+    def test_empty_file_is_valid(self, tmp_path) -> None:
+        path = tmp_path / "c.toml"
+        path.write_text("")
+        assert load(path) == Config(sources=(str(path),))
+
+    @pytest.mark.parametrize(
+        ("content", "fragment"),
+        [
+            ('show = ["*_KEY"]', "wildcard"),
+            ('show = ["A?B"]', "wildcard"),
+            ('show = ["A[0-9]"]', "wildcard"),
+            ('[files."x.env"]\nshow = ["*_KEY"]', "wildcard"),
+            ('shwo = ["X"]', "unknown setting"),
+            ("[detection]\nlevel = 3", "unknown setting"),
+            ('[files."x.env"]\nmode = "normal"', "unknown setting"),
+            ('[detection]\nmode = "paranoid"', "detection.mode"),
+            ('[detection]\nentropy_threshold = "high"', "must be a number"),
+            ("[detection]\nentropy_threshold = true", "must be a number"),
+            ('root = "yes"', "must be true or false"),
+            ('show = "KEY"', "must be a list of strings"),
+            ("show = [1, 2]", "must be a list of strings"),
+            ('detection = "aggressive"', "must be a table"),
+            ('files = "x.env"', "must be a table"),
+            ('[files]\nx = "not a table"', "must be a table"),
+        ],
+    )
+    def test_rejects_bad_input(self, tmp_path, content: str, fragment: str) -> None:
+        path = tmp_path / "c.toml"
+        path.write_text(content)
+        with pytest.raises(ConfigError, match=fragment):
+            load(path)
+
+    def test_wildcards_are_fine_in_hide(self, tmp_path) -> None:
+        """Over-redaction is visible and harmless; under-redaction is not."""
+        path = tmp_path / "c.toml"
+        path.write_text('hide = ["*_URL", "TOKEN?", "X[0-9]"]')
+        assert len(load(path).hide) == 3
+
+    def test_malformed_toml(self, tmp_path) -> None:
+        path = tmp_path / "c.toml"
+        path.write_text("hide = [")
+        with pytest.raises(ConfigError, match="invalid TOML"):
+            load(path)
+
+    def test_unreadable_file(self, tmp_path) -> None:
+        with pytest.raises(ConfigError, match="cannot read"):
+            load(tmp_path / "missing.toml")
+
+
+class TestMatching:
+    """show is exact; hide is a glob. Both case-insensitive."""
+
+    def test_show_is_exact(self) -> None:
+        config = Config(show=("DEPLOY_PUBLIC_KEY",))
+        assert config.shows("DEPLOY_PUBLIC_KEY") == "DEPLOY_PUBLIC_KEY"
+        assert config.shows("deploy_public_key") == "DEPLOY_PUBLIC_KEY"
+        assert config.shows("MY_DEPLOY_PUBLIC_KEY") is None
+        assert config.shows("DEPLOY_PUBLIC_KEY_2") is None
+
+    def test_hide_is_a_glob(self) -> None:
+        config = Config(hide=("*_NOTIFICATION_URL",))
+        assert config.hides("WATCHTOWER_NOTIFICATION_URL") == "*_NOTIFICATION_URL"
+        assert config.hides("watchtower_notification_url") == "*_NOTIFICATION_URL"
+        assert config.hides("NOTIFICATION_URL_BACKUP") is None
+
+    def test_for_file_applies_a_section(self) -> None:
+        config = Config(files=(("demo.env", Config(show=("API_TOKEN",))),))
+        assert config.for_file("demo.env").shows("API_TOKEN") == "API_TOKEN"
+        assert config.for_file("DEMO.ENV").shows("API_TOKEN") == "API_TOKEN"
+        assert config.for_file("other.env").shows("API_TOKEN") is None
+
+
+class TestMerging:
+    def test_lists_union_and_scalars_take_the_overlay(self) -> None:
+        base = Config(show=("A",), hide=("X*",), mode="normal", entropy_threshold=4.5)
+        overlay = Config(show=("B",), hide=("Y*",), mode="aggressive")
+        result = merge(base, overlay)
+
+        assert result.show == ("A", "B")
+        assert result.hide == ("X*", "Y*")
+        assert result.mode == "aggressive"
+        assert result.entropy_threshold == 4.5  # not overridden by None
+
+    def test_union_drops_duplicates_and_keeps_order(self) -> None:
+        assert merge(Config(show=("A", "B")), Config(show=("B", "C"))).show == ("A", "B", "C")
+
+    def test_without_show_strips_top_level_and_sections(self) -> None:
+        config = Config(show=("A",), hide=("X*",), files=(("f.env", Config(show=("B",), hide=("Y*",))),))
+        stripped = without_show(config)
+
+        assert stripped.show == ()
+        assert stripped.files[0][1].show == ()
+        assert stripped.hide == ("X*",)
+        assert stripped.files[0][1].hide == ("Y*",)
+
+
+class TestDiscovery:
+    def test_walks_upward_nearest_last(self, tmp_path) -> None:
+        (tmp_path / "a" / "b").mkdir(parents=True)
+        (tmp_path / ".secretscreen.toml").write_text('hide = ["OUTER"]')
+        (tmp_path / "a" / "b" / ".secretscreen.toml").write_text('hide = ["INNER"]')
+
+        found = discover(tmp_path / "a" / "b", stop_at=tmp_path)
+        assert [p.parent.name for p in found] == [tmp_path.name, "b"]
+
+    def test_root_flag_halts_the_walk(self, tmp_path) -> None:
+        (tmp_path / "a").mkdir()
+        (tmp_path / ".secretscreen.toml").write_text('hide = ["OUTER"]')
+        (tmp_path / "a" / ".secretscreen.toml").write_text("root = true")
+
+        found = discover(tmp_path / "a", stop_at=tmp_path)
+        assert len(found) == 1
+
+    def test_no_configs(self, tmp_path) -> None:
+        assert discover(tmp_path, stop_at=tmp_path) == []
+
+    def test_broken_config_does_not_break_the_walk(self, tmp_path) -> None:
+        """The file is still reported when loaded; the walk itself must survive."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "a" / ".secretscreen.toml").write_text("hide = [")
+        assert len(discover(tmp_path / "a", stop_at=tmp_path)) == 1
+
+    def test_user_path_honours_xdg(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        assert user_config_path() == tmp_path / "secretscreen.toml"
+
+    def test_user_path_falls_back_to_dot_config(self, monkeypatch) -> None:
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        assert user_config_path().parent.name == ".config"
+
+
+class TestRulesEndToEnd:
+    ENV = "API_TOKEN=realsecret\nDEPLOY_KEY=ssh-rsa AAAAfake\nLOG_LEVEL=debug\n"
+
+    def test_show_prevents_redaction(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["API_TOKEN"]')
+        main([_write(isolated, "a.env", self.ENV)])
+        assert "API_TOKEN=realsecret" in capsys.readouterr().out
+
+    def test_hide_forces_redaction_of_a_clean_key(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["LOG_*"]')
+        main([_write(isolated, "a.env", self.ENV)])
+        assert "LOG_LEVEL=[REDACTED]" in capsys.readouterr().out
+
+    def test_hide_beats_show(self, isolated, capsys) -> None:
+        """At every scope. A narrower rule must never make the tool quieter."""
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["API_TOKEN"]\nhide = ["API_*"]')
+        main([_write(isolated, "a.env", self.ENV)])
+        assert "realsecret" not in capsys.readouterr().out
+
+    def test_rules_match_keys_behind_a_grep_prefix(self, isolated, capsys) -> None:
+        """The normalised key is what rules see, not the line as grep wrote it.
+
+        `grep -n` yields `a.env:1:API_TOKEN=...`, where the first colon belongs
+        to the line number. An exact-match show rule would silently never fire
+        against that, and the failure is invisible: the value stays redacted,
+        which is what an unconfigured run looks like.
+        """
+        piped = "a.env:1:API_TOKEN=realsecret\na.env:2:LOG_LEVEL=debug\na.env:3:DEPLOY_KEY=ssh-rsa AAAAfake\n"
+        main([_write(isolated, "piped.txt", piped), "--no-config", "--show", "API_TOKEN", "--hide", "LOG_*"])
+        out = capsys.readouterr().out
+
+        assert "a.env:1:API_TOKEN=realsecret" in out
+        assert "a.env:2:LOG_LEVEL=[REDACTED]" in out
+
+    def test_show_flag_rejects_wildcards_like_the_file_does(self, isolated, capsys) -> None:
+        """Exact matching makes an unchecked wildcard a silent no-op, not an error."""
+        code = main([_write(isolated, "a.env", self.ENV), "--no-config", "--show", "*_TOKEN"])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_ERROR
+        assert "must name keys exactly" in captured.err
+        assert captured.out == ""
+
+    def test_flags_work_without_any_file(self, isolated, capsys) -> None:
+        main([_write(isolated, "a.env", self.ENV), "--no-config", "--hide", "LOG_*"])
+        assert "LOG_LEVEL=[REDACTED]" in capsys.readouterr().out
+
+    def test_explicit_config_replaces_discovery(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["LOG_*"]')
+        explicit = _write(isolated, "other.toml", 'show = ["API_TOKEN"]')
+        main([_write(isolated, "a.env", self.ENV), "--config", explicit])
+        out = capsys.readouterr().out
+
+        assert "API_TOKEN=realsecret" in out
+        assert "LOG_LEVEL=debug" in out
+
+    def test_no_config_ignores_files(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["API_TOKEN"]')
+        main([_write(isolated, "a.env", self.ENV), "--no-config"])
+        assert "realsecret" not in capsys.readouterr().out
+
+    def test_per_file_section(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('[files."demo.env"]\nshow = ["API_TOKEN"]')
+        main([_write(isolated, "demo.env", self.ENV)])
+        assert "API_TOKEN=realsecret" in capsys.readouterr().out
+
+        main([_write(isolated, "prod.env", self.ENV)])
+        assert "realsecret" not in capsys.readouterr().out
+
+    def test_mode_and_threshold_from_config(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text(
+            '[detection]\nmode = "aggressive"\nentropy_threshold = 3.0\n'
+        )
+        main([_write(isolated, "a.env", "BLOB=abcdefghijklmnopqrstuvwxyz012345\n")])
+        assert "BLOB=[REDACTED]" in capsys.readouterr().out
+
+    def test_flag_beats_config_for_threshold(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('[detection]\nmode = "aggressive"\nentropy_threshold = 3.0')
+        main([_write(isolated, "a.env", "BLOB=abcdefghijklmnopqrstuvwxyz012345\n"), "--entropy-threshold", "9.0"])
+        assert "BLOB=abcdefghijklmnopqrstuvwxyz012345" in capsys.readouterr().out
+
+
+class TestDiscoveredConfigsCannotLoosen:
+    """A file found on disk may tighten redaction but not relax it.
+
+    A project config can arrive with a cloned repository. Letting it decide
+    which of the reader's credentials get printed is not a decision the
+    repository author should have.
+    """
+
+    def test_project_show_is_ignored_by_default(self, isolated, capsys) -> None:
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text('show = ["API_TOKEN"]')
+        main([_write(stack, "a.env", "API_TOKEN=realsecret\n")])
+        captured = capsys.readouterr()
+
+        assert "realsecret" not in captured.out
+        assert "show entries ignored" in captured.err
+        # Every "loaded config" line names a file that was loaded. The marker
+        # for the stripped show entries is a note, not a source.
+        loaded = [line for line in captured.err.splitlines() if "loaded config" in line]
+        assert all(line.endswith(".secretscreen.toml") for line in loaded), loaded
+
+    def test_trust_config_honours_it(self, isolated, capsys) -> None:
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text('show = ["API_TOKEN"]')
+        main([_write(stack, "a.env", "API_TOKEN=realsecret\n"), "--trust-config"])
+        assert "API_TOKEN=realsecret" in capsys.readouterr().out
+
+    def test_project_hide_always_applies(self, isolated, capsys) -> None:
+        stack = isolated / "stack"
+        stack.mkdir()
+        (stack / ".secretscreen.toml").write_text('hide = ["LOG_*"]')
+        main([_write(stack, "a.env", "LOG_LEVEL=debug\n")])
+        assert "LOG_LEVEL=[REDACTED]" in capsys.readouterr().out
+
+    def test_user_config_may_show(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["API_TOKEN"]')
+        main([_write(isolated, "a.env", "API_TOKEN=realsecret\n")])
+        assert "API_TOKEN=realsecret" in capsys.readouterr().out
+
+
+class TestPerInputDiscovery:
+    """Discovery runs per input, not once per process."""
+
+    def test_two_files_in_different_directories_get_different_rules(self, isolated, capsys) -> None:
+        one, two = isolated / "watchtower", isolated / "nextcloud"
+        one.mkdir()
+        two.mkdir()
+        (one / ".secretscreen.toml").write_text('hide = ["POLL_INTERVAL"]')
+        (two / ".secretscreen.toml").write_text('hide = ["TRUSTED_DOMAINS"]')
+
+        body = "POLL_INTERVAL=86400\nTRUSTED_DOMAINS=cloud.example.com\n"
+        main([_write(one, "compose.yaml", body), _write(two, "compose.yaml", body)])
+        out = capsys.readouterr().out
+
+        first, second = out.split("POLL_INTERVAL", 2)[1], out.split("POLL_INTERVAL", 2)[2]
+        assert "[REDACTED]" in first  # watchtower's rule
+        assert "86400" in second  # and not applied to nextcloud
+        assert "TRUSTED_DOMAINS=cloud.example.com" in first
+        assert "TRUSTED_DOMAINS=[REDACTED]" in second
+
+
+class TestRulesInEveryMode:
+    def test_explain_reports_rules_distinctly(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["API_TOKEN"]\nhide = ["LOG_*"]')
+        main([_write(isolated, "a.env", "API_TOKEN=realsecret\nLOG_LEVEL=debug\n"), "--explain"])
+        err = capsys.readouterr().err
+
+        assert "show rule 'API_TOKEN' — not examined" in err
+        assert "hide rule 'LOG_*'" in err
+        assert "realsecret" not in err
+
+    def test_audit_skips_shown_and_reports_hidden(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["API_TOKEN"]\nhide = ["LOG_*"]')
+        code = main([_write(isolated, "a.env", "API_TOKEN=realsecret\nLOG_LEVEL=debug\n"), "--audit"])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_FINDINGS
+        assert "LOG_LEVEL" in out
+        assert "API_TOKEN" not in out
+        assert "realsecret" not in out
+
+    def test_json_honours_rules(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["password"]\nhide = ["host"]')
+        main([_write(isolated, "c.json", '{"password": "hunter2", "host": "db.lan"}')])
+        out = capsys.readouterr().out
+
+        assert "hunter2" in out
+        assert "db.lan" not in out
+
+    def test_json_without_rules_is_unchanged(self, isolated, capsys) -> None:
+        main([_write(isolated, "c.json", '{"password": "hunter2", "host": "db.lan"}')])
+        out = capsys.readouterr().out
+
+        assert "hunter2" not in out
+        assert "db.lan" in out
+
+    def test_json_rules_reach_nested_structures(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["password"]\nhide = ["region"]')
+        document = '{"services": [{"db": {"password": "hunter2", "region": "eu-west"}}, {"tags": ["a", "b"]}]}'
+        main([_write(isolated, "c.json", document)])
+        out = capsys.readouterr().out
+
+        assert "hunter2" in out  # shown despite being nested two levels down
+        assert "eu-west" not in out  # hidden despite being otherwise clean
+        assert '"a"' in out  # untouched leaves survive the overlay
+
+    def test_json_audit_reports_nested_hidden_keys(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["region"]')
+        document = '{"services": [{"db": {"region": "eu-west"}}]}'
+        code = main([_write(isolated, "c.json", document), "--audit"])
+        out = capsys.readouterr().out
+
+        assert code == EXIT_FINDINGS
+        assert "region" in out
+        assert "eu-west" not in out
+
+    def test_json_audit_agrees_with_redaction_on_case(self, isolated, capsys) -> None:
+        """A rule that stops redaction must also stop the finding, in either spelling.
+
+        Everything else matches keys case-insensitively. An --audit that
+        reported a key the redact pass prints would send a script chasing a
+        finding that the tool itself has already decided to vouch for.
+        """
+        body = '{"DB_PASSWORD": "hunter2"}'
+        code = main([_write(isolated, "a.json", body), "--no-config", "--audit", "--show", "db_password"])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_OK
+        assert captured.out == ""
+
+    def test_json_explain_reports_rules(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["host"]')
+        main([_write(isolated, "c.json", '{"host": "db.lan"}'), "--explain"])
+        assert "hide rule 'host'" in capsys.readouterr().err
+
+    def test_dsn_honours_rules(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["dsn"]')
+        main([_write(isolated, "d.txt", "postgres://u:p@h/db\n"), "--format", "dsn"])
+        assert capsys.readouterr().out.strip() == "[REDACTED]"
+
+
+class TestConfigErrorsAreFatal:
+    def test_bad_config_exits_two_and_prints_nothing(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('show = ["*_KEY"]')
+        code = main([_write(isolated, "a.env", "API_TOKEN=realsecret\n")])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_ERROR
+        assert captured.out == ""
+        assert "wildcard" in captured.err
+
+    def test_loaded_configs_are_announced(self, isolated, capsys) -> None:
+        (isolated / "xdg" / "secretscreen.toml").write_text('hide = ["LOG_*"]')
+        main([_write(isolated, "a.env", "LOG_LEVEL=debug\n")])
+        assert "loaded config" in capsys.readouterr().err
+
+    def test_no_announcement_when_there_is_no_config(self, isolated, capsys) -> None:
+        code = main([_write(isolated, "a.env", "LOG_LEVEL=debug\n")])
+        captured = capsys.readouterr()
+
+        assert code == EXIT_OK
+        assert "loaded config" not in captured.err


### PR DESCRIPTION
Closes the config-file item: `~/.config/secretscreen.toml` plus `.secretscreen.toml` discovered upward, the `show`/`hide` rules argued out on Jul 30, and the flags that were listed alongside them.

## Why the rules are asymmetric

Config exists to stop the same false positive being re-diagnosed every run. It cannot do the same for a false negative — a missed secret leaves no trace to configure against, which is why `--explain` came first.

So `hide` takes globs and `show` does not. `show = ["*_KEY"]` would print `AWS_SECRET_ACCESS_KEY`, `AUTHENTIK_SECRET_KEY`, `STRIPE_API_KEY`, and it would go on matching keys nobody has written yet. Every entry is a credential someone is choosing to print, so every entry gets named in full. `hide` wins over `show` at every scope: a narrower rule that could un-hide something would be the one setting where being more specific makes the tool quieter.

## Discovery runs per input

Not once per process. `secretscreen watchtower/compose.yaml nextcloud/compose.yaml` picks up the config beside each one — basename keying alone can't separate two files with the same name, so the walk starts at each input's own directory. `root = true` stops it.

Order is user config, then project configs furthest to nearest, then flags. Lists union rather than replace, so a closer file extends the broader one instead of silently discarding it — the mistake `safe_suffixes` makes in the library API, where passing one suffix drops the other twenty.

## A discovered config may tighten, never loosen

Its `show` entries are ignored unless you pass `--trust-config`. A `.secretscreen.toml` can arrive with a repository cloned five minutes ago, and which of your credentials get printed is not that author's decision. Only your own `~/.config` file can loosen anything.

Malformed config is fatal rather than skipped — bad TOML, an unknown setting, a wildcard where none is allowed. A typo that quietly disabled a `hide` rule would leave you believing you had configured something you had not.

`--explain` reports a show rule as `vetoed`, not `clean`: the value was not examined, it was vouched for. That is the line to read when a rule written a year ago is covering a secret added last week.

## Also in scope, and previously missing

`--version` — a published CLI without one gives no way to report a bug against the right release. And a help epilog that carries what the flag list cannot: worked examples, the three exit codes (`0` clean, `1` `--audit` found something, `2` unparsed, unreadable, or invalid config), and the guarantee that `--audit` never prints a value in any mode.

## Three defects found by probing the branch, not by running its tests

- **`--show '*_KEY'` was accepted on the command line and silently never fired.** The file loader rejects wildcards loudly; the flag validated nothing, and exact matching turned it into a no-op — which reads exactly like a rule that is in force. Both paths now share one check.
- **`--audit` disagreed with redaction on JSON.** `--show db_password` against `{"DB_PASSWORD": ...}` printed the value in redact mode but still reported a finding and exited 1 under `--audit`, because that path compared the rule's spelling to the key while matching is case-insensitive everywhere else. A script gating on the exit code would chase a key the tool had already vouched for.
- **`without_show` pushed its reason string into `sources`**, so stderr announced `loaded config show entries ignored` as though that were a filename.

## Tests

322 → 384, including the case the design called for explicitly: rules match the *normalised* key, so an exact `show` entry still fires against `a.env:1:API_TOKEN=...`. Without prefix stripping that match silently never happens, and the failure is invisible — the value stays redacted, which is what an unconfigured run looks like.

Green on 3.11 and 3.13 locally; ruff check, ruff format and mypy clean.