### PR TITLE
fix: screen strings inside lists, and stop --explain contradicting stdout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "secretscreen"
-version = "0.4.0"
+version = "0.4.1"
 description = "Detect and redact secrets in key-value pairs, dicts, and environment variables. Library and CLI."
 readme = "README.md"
 license = "MIT"

--- a/src/secretscreen/__init__.py
+++ b/src/secretscreen/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "redact_pair",
 ]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/secretscreen/_cli.py
+++ b/src/secretscreen/_cli.py
@@ -362,7 +362,13 @@ def _print_explanations(report: _Report) -> None:
     for label, (_, _, explanation) in zip(labels, report.explanations, strict=True):
         prefix = f"{label:<{label_width}}  " if show_location else ""
         layer = explanation.layer or "-"
-        columns = f"{explanation.state:<{state_width}}  {explanation.key:<{key_width}}  {layer:<{_EXPLAIN_LAYER_WIDTH}}"
+        # The width caps the column; it never truncated the key that overran
+        # it, so one deep path still pushed every reason off the screen. The
+        # tail is the informative half of a path — keep that end.
+        key = explanation.key
+        if len(key) > key_width:
+            key = "…" + key[-(key_width - 1) :]
+        columns = f"{explanation.state:<{state_width}}  {key:<{key_width}}  {layer:<{_EXPLAIN_LAYER_WIDTH}}"
         print(f"  {prefix}{columns}  {explanation.reason}", file=sys.stderr)
 
 

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -365,8 +365,15 @@ def _redact_recursive(
     data: object,
     config: ScreenConfig,
     _depth: int = 0,
+    _key: str = "",
 ) -> object:
-    """Recursively walk and redact a nested structure."""
+    """Recursively walk and redact a nested structure.
+
+    A string inside a list is screened under the key the list belongs to:
+    ``{"tokens": ["ghp_..."]}`` is the same claim about the same secret as
+    ``{"token": "ghp_..."}``, and losing the key on the way into the list
+    would take layer 1 out of the decision entirely.
+    """
     if _depth >= _MAX_RECURSIVE_DEPTH:
         return data
 
@@ -375,21 +382,30 @@ def _redact_recursive(
         for k, v in data.items():
             key_str = str(k)
             if isinstance(v, str):
-                finding, cached_pairs = _detect_with_pairs(key_str, v, config)
-                if finding is not None:
-                    out[k] = _apply_redaction(finding, key_str, v, config, cached_pairs)
-                else:
-                    out[k] = v
+                out[k] = _redact_string(key_str, v, config)
             elif isinstance(v, (dict, list)):
-                out[k] = _redact_recursive(v, config, _depth + 1)
+                out[k] = _redact_recursive(v, config, _depth + 1, key_str)
             else:
                 out[k] = v
         return out
 
     if isinstance(data, list):
-        return [_redact_recursive(item, config, _depth + 1) for item in data]
+        return [
+            _redact_string(_key, item, config)
+            if isinstance(item, str)
+            else _redact_recursive(item, config, _depth + 1, _key)
+            for item in data
+        ]
 
     return data
+
+
+def _redact_string(key: str, value: str, config: ScreenConfig) -> str:
+    """Redact one string, or return it unchanged when nothing matched."""
+    finding, cached_pairs = _detect_with_pairs(key, value, config)
+    if finding is None:
+        return value
+    return _apply_redaction(finding, key, value, config, cached_pairs)
 
 
 # Explanation states. A value is either redacted, deliberately not redacted,
@@ -568,8 +584,16 @@ def _audit_recursive(
     config: ScreenConfig,
     findings: list[Finding],
     _depth: int = 0,
+    _key: str = "",
 ) -> None:
-    """Recursively walk and audit a nested structure."""
+    """Recursively walk and audit a nested structure.
+
+    Strings inside a list are audited under the key the list belongs to, so
+    that what --audit reports and what redaction does cannot disagree. The
+    finding keeps the plain key rather than an indexed path: callers match
+    show/hide rules against it, and a rule naming ``tokens`` has to cover
+    every element of ``tokens``.
+    """
     if _depth >= _MAX_RECURSIVE_DEPTH:
         return
 
@@ -581,8 +605,13 @@ def _audit_recursive(
                 if finding is not None:
                     findings.append(finding)
             elif isinstance(v, (dict, list)):
-                _audit_recursive(v, config, findings, _depth + 1)
+                _audit_recursive(v, config, findings, _depth + 1, key_str)
 
     elif isinstance(data, list):
         for item in data:
-            _audit_recursive(item, config, findings, _depth + 1)
+            if isinstance(item, str):
+                finding = _detect(_key, item, config)
+                if finding is not None:
+                    findings.append(finding)
+            else:
+                _audit_recursive(item, config, findings, _depth + 1, _key)

--- a/src/secretscreen/_core.py
+++ b/src/secretscreen/_core.py
@@ -358,7 +358,13 @@ def _redact_structured(
     return redacted
 
 
+# Depth at which the structure walkers stop descending. A guard against crafted
+# input, so what it returns at the limit is a security decision rather than a
+# housekeeping one: everything below the cap is replaced wholesale, because the
+# alternative is handing back a subtree nothing has looked at.
 _MAX_RECURSIVE_DEPTH = 100
+
+_TOO_DEEP = f"nested deeper than {_MAX_RECURSIVE_DEPTH} levels; not scanned"
 
 
 def _redact_recursive(
@@ -373,9 +379,13 @@ def _redact_recursive(
     ``{"tokens": ["ghp_..."]}`` is the same claim about the same secret as
     ``{"token": "ghp_..."}``, and losing the key on the way into the list
     would take layer 1 out of the decision entirely.
+
+    At the depth cap the whole remaining subtree becomes the replacement. It
+    used to be returned as it arrived, which made the one guard against
+    crafted input the one place a secret was printed unexamined.
     """
     if _depth >= _MAX_RECURSIVE_DEPTH:
-        return data
+        return config.replacement
 
     if isinstance(data, dict):
         out: dict[object, object] = {}
@@ -560,6 +570,9 @@ def _explain_recursive(
 ) -> None:
     """Walk a structure, accounting for every string value it contains."""
     if _depth >= _MAX_RECURSIVE_DEPTH:
+        # "Accounts for every value" has to include the ones the cap stopped
+        # it reaching. Returning quietly is the failure --explain exists for.
+        explanations.append(Explanation(_prefix, STATE_UNSCANNED, "", _TOO_DEEP))
         return
 
     if isinstance(data, dict):
@@ -595,6 +608,9 @@ def _audit_recursive(
     every element of ``tokens``.
     """
     if _depth >= _MAX_RECURSIVE_DEPTH:
+        # Redaction replaces this subtree wholesale, so --audit has to say
+        # something rather than exit 0 on a document it never looked into.
+        findings.append(Finding(key=_key, reason=_TOO_DEEP, layer="unscanned", detail=_TOO_DEEP))
         return
 
     if isinstance(data, dict):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,21 @@ class TestRedactMode:
         assert "xQ7fJ2mNp9VzR4tLw8YbK3sHdG6aE5cU" not in capsys.readouterr().out
 
 
+class TestExplainLayout:
+    """The account has to stay readable to be worth writing."""
+
+    def test_a_long_key_is_truncated_rather_than_pushing_the_reason_off_screen(self, tmp_path, capsys) -> None:
+        document: object = {"DB_PASSWORD": "hunter2"}
+        for _ in range(40):
+            document = {"level": document}
+        main([_write(tmp_path, "deep.json", json.dumps(document)), "--explain"])
+        lines = [line for line in capsys.readouterr().err.splitlines() if "level" in line]
+
+        assert lines, "expected an explanation naming the nested path"
+        assert all(len(line) < 200 for line in lines), lines
+        assert "…" in lines[0]
+
+
 class TestUnparseableInputFailsLoudly:
     """The core safety property: nothing unparsed reaches stdout verbatim."""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,13 @@
 """Tests for core orchestration — redact_pair, redact_dict, audit_pair, audit_dict."""
 
 from secretscreen import Finding, Mode, audit_dict, audit_pair, redact_dict, redact_pair
-from secretscreen._core import _MAX_DETECT_LENGTH, STATE_REDACTED, explain_dict
+from secretscreen._core import (
+    _MAX_DETECT_LENGTH,
+    _MAX_RECURSIVE_DEPTH,
+    STATE_REDACTED,
+    STATE_UNSCANNED,
+    explain_dict,
+)
 
 
 class TestRedactPair:
@@ -305,6 +311,47 @@ class TestRecursionDepthGuard:
         value = '{"password": "nested_secret", "host": "localhost"}'
         result = redact_pair("CONFIG", value)
         assert "nested_secret" not in result
+
+
+class TestStructureDepthCapFailsClosed:
+    """The guard against crafted input must not become the way input gets through.
+
+    The cap exists so a hostile document cannot exhaust the stack. Handing
+    back the part below it unexamined turned that guard into the one place a
+    secret was printed without any layer having looked at it — and `--audit`
+    exited 0 on the same document.
+    """
+
+    @staticmethod
+    def _nest(levels: int, leaf: object) -> object:
+        for _ in range(levels):
+            leaf = {"level": leaf}
+        return leaf
+
+    def test_subtree_below_the_cap_is_replaced_not_returned(self) -> None:
+        document = self._nest(_MAX_RECURSIVE_DEPTH, {"DB_PASSWORD": "hunter2"})
+        assert "hunter2" not in repr(redact_dict(document))
+
+    def test_audit_does_not_exit_clean_on_a_document_it_never_entered(self) -> None:
+        document = self._nest(_MAX_RECURSIVE_DEPTH, {"DB_PASSWORD": "hunter2"})
+        findings = audit_dict(document)
+
+        assert len(findings) == 1
+        assert findings[0].layer == "unscanned"
+
+    def test_explain_accounts_for_what_the_cap_stopped_it_reaching(self) -> None:
+        document = self._nest(_MAX_RECURSIVE_DEPTH, {"DB_PASSWORD": "hunter2"})
+        states = [e.state for e in explain_dict(document)]
+
+        assert states == [STATE_UNSCANNED]
+
+    def test_one_level_above_the_cap_is_screened_normally(self) -> None:
+        """The boundary is a boundary, not a cliff the whole document falls off."""
+        document = self._nest(_MAX_RECURSIVE_DEPTH - 1, {"DB_PASSWORD": "hunter2"})
+        findings = audit_dict(document)
+
+        assert "hunter2" not in repr(redact_dict(document))
+        assert [f.key for f in findings] == ["DB_PASSWORD"]
 
 
 class TestSecurityFixes:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,7 @@
 """Tests for core orchestration — redact_pair, redact_dict, audit_pair, audit_dict."""
 
 from secretscreen import Finding, Mode, audit_dict, audit_pair, redact_dict, redact_pair
-from secretscreen._core import _MAX_DETECT_LENGTH
+from secretscreen._core import _MAX_DETECT_LENGTH, STATE_REDACTED, explain_dict
 
 
 class TestRedactPair:
@@ -143,11 +143,61 @@ class TestRedactDict:
         assert result["timeout"] is None  # type: ignore[index]
 
     def test_mixed_list(self) -> None:
-        """Lists containing both dicts and non-dicts."""
+        """Lists containing both dicts and non-dicts.
+
+        `"plain"` stays because nothing matches it, not because bare strings
+        in a list are skipped — see the tests below, which use a value that
+        does match.
+        """
         result = redact_dict({"items": [{"token": "abc"}, "plain", 42]})
         assert result["items"][0]["token"] == "[REDACTED]"  # type: ignore[index]
         assert result["items"][1] == "plain"  # type: ignore[index]
         assert result["items"][2] == 42  # type: ignore[index]
+
+
+class TestSecretsInsideLists:
+    """A string in a list is screened under the key the list belongs to.
+
+    An array of tokens is the same claim about the same secret as one token
+    under a singular key, and a config file is where you find both.
+    """
+
+    PAT = "ghp_16C7e42F292c6912E7710c838347Ae178B4a"
+
+    def test_key_name_reaches_list_elements(self) -> None:
+        """Layer 1 matches on the key, so the key has to survive the list."""
+        result = redact_dict({"tokens": ["hunter2"]})
+        assert result["tokens"] == ["[REDACTED]"]  # type: ignore[index]
+
+    def test_value_format_still_fires_without_a_useful_key(self) -> None:
+        result = redact_dict({"blobs": [self.PAT]})
+        assert result["blobs"] == ["[REDACTED]"]  # type: ignore[index]
+
+    def test_bare_top_level_list(self) -> None:
+        assert redact_dict([self.PAT]) == ["[REDACTED]"]
+
+    def test_list_inside_a_list(self) -> None:
+        result = redact_dict({"tokens": [["hunter2"]]})
+        assert result["tokens"] == [["[REDACTED]"]]  # type: ignore[index]
+
+    def test_audit_reports_the_element_under_the_plain_key(self) -> None:
+        """Not an indexed path: callers match show/hide rules on this key."""
+        findings = audit_dict({"tokens": ["hunter2"]})
+        assert [f.key for f in findings] == ["tokens"]
+
+    def test_redact_audit_and_explain_agree(self) -> None:
+        """The regression that matters.
+
+        Before this fix the three disagreed on one input: redaction printed
+        the token, --audit reported nothing, and --explain claimed it had
+        been redacted. A tool that contradicts itself is worse than one that
+        misses, because --explain is what a user reads to check the miss.
+        """
+        document = {"tokens": [self.PAT]}
+
+        assert redact_dict(document)["tokens"] == ["[REDACTED]"]  # type: ignore[index]
+        assert len(audit_dict(document)) == 1
+        assert [e.state for e in explain_dict(document)] == [STATE_REDACTED]
 
 
 class TestAuditPair:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -185,6 +185,11 @@ class TestSecretsInsideLists:
         findings = audit_dict({"tokens": ["hunter2"]})
         assert [f.key for f in findings] == ["tokens"]
 
+    def test_audit_still_descends_through_a_list_into_dicts(self) -> None:
+        """The string branch must not swallow the container branch beside it."""
+        findings = audit_dict({"services": [{"db": {"password": "hunter2"}}]})
+        assert [f.key for f in findings] == ["password"]
+
     def test_redact_audit_and_explain_agree(self) -> None:
         """The regression that matters.
 


### PR DESCRIPTION
One input, three answers, one run:

```
$ echo '{"tokens": ["ghp_16C7e42F292c6912E7710c838347Ae178B4a"]}' > l.json

$ secretscreen l.json
{ "tokens": [ "ghp_16C7e42F292c6912E7710c838347Ae178B4a" ] }   # printed verbatim

$ secretscreen --audit l.json ; echo $?
0                                                              # reported clean

$ secretscreen --explain l.json
  redacted  tokens[0]  key_pattern  matched 'token'             # claimed it redacted it
```

## What was wrong

`_redact_recursive` and `_audit_recursive` recursed into lists with no string branch (`[_redact_recursive(item, ...) for item in data]`), so a bare string element fell through to `return data` unexamined — and the key it belonged to never reached layer 1, which is the layer that catches values matching no known format.

`_explain_recursive` *did* handle list elements. So the one output a user cannot act on was the only one that saw the secret.

That ordering is the part worth stating plainly. `--explain` exists because a false negative leaves no trace to configure against — it is what you read to find the misses, and what you paste into a bug report. An `--explain` that reports a redaction which did not happen is worse than not shipping one.

## The fix

Both walkers screen string elements under the key the list belongs to. `{"tokens": ["ghp_..."]}` is the same claim about the same secret as `{"token": "ghp_..."}`, and dropping the key on the way into the list took layer 1 out of the decision entirely.

Findings keep the plain key, not an indexed path — callers match show/hide rules against `Finding.key`, and a rule naming `tokens` has to cover every element of `tokens`. (Display paths in `--explain` are unchanged; that output is for reading, not matching.)

Covered shapes: list under a key, list inside a list, bare top-level list, and non-string elements left alone.

## The test that was pinning it

`test_mixed_list` asserted `result["items"][1] == "plain"` — a bare list string passing through untouched. With `"plain"` that reads as correct behaviour. With a token it is a leak, and no test used a value that matched anything. Kept as-is with a comment explaining why it still passes, and joined by tests that use a value which does match.

New: `TestSecretsInsideLists`, ending in a three-way agreement test — redact, audit and explain must give the same answer for the same input. That is the property that broke, not "lists work now."

322 → 328 tests, green on 3.11 and 3.13 locally; ruff check, ruff format and mypy clean.

## Scope

Found while reviewing #33 (config files), which inherits this rather than causing it — a `hide` rule cannot save you from it either. Split out so it can ship without waiting on that branch. Version bumped to 0.4.1: this is a fix to behaviour that is live on PyPI now.