### PR TITLE
ci: require every src change to arrive with a test that fails without it

### DIFF
--- a/.github/scripts/pr_test_gate.py
+++ b/.github/scripts/pr_test_gate.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Require every behaviour change to arrive with a test that proves it.
+
+The gate runs the pull request's own tests against the pull request's *base*
+source. At least one newly added test must fail there, and every changed test
+must pass once the patch is applied. A test that passes without the patch does
+not demonstrate anything; it is the failure on base that turns a test into
+evidence.
+
+Exit codes: 0 pass, 1 gate failure, 2 harness error.
+
+Run it locally the same way CI does:
+
+    python .github/scripts/pr_test_gate.py --base origin/main --head HEAD
+
+Escape hatch: a pull request that genuinely changes no behaviour (a pure
+refactor, a rename, a performance change covered by existing tests) is exempt
+via the `no-test-gate` label. The label is checked by the workflow, not here,
+so that the reason is recorded on the pull request rather than buried in a log.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SRC_DIR = "src"
+TEST_DIR = "tests"
+
+# `def test_x`, `async def test_x`, added by the diff.
+ADDED_TEST_RE = re.compile(r"^\+\s*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)")
+# pytest's short summary lines: "FAILED tests/test_x.py::Cls::test_y - detail"
+OUTCOME_RE = re.compile(r"^(?:FAILED|ERROR)\s+(\S+)")
+
+
+class GateError(RuntimeError):
+    """The gate could not run. Distinct from the gate deciding to fail."""
+
+
+def git(*args: str) -> str:
+    result = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise GateError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def changed_files(base: str, head: str, path: str) -> list[str]:
+    out = git("diff", "--name-only", "--diff-filter=ACMR", base, head, "--", path)
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def added_test_names(base: str, head: str) -> set[str]:
+    diff = git("diff", base, head, "--", TEST_DIR)
+    return {match.group(1) for line in diff.splitlines() if (match := ADDED_TEST_RE.match(line))}
+
+
+def run_pytest(paths: list[str]) -> tuple[int, str, set[str]]:
+    """Run pytest over `paths`; return (exit code, output, failing test names)."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *paths,
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+            "--tb=no",
+            "-rfE",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    failing = set()
+    for line in output.splitlines():
+        if match := OUTCOME_RE.match(line):
+            # tests/test_core.py::TestFoo::test_bar -> test_bar
+            failing.add(match.group(1).split("::")[-1].split("[")[0])
+    return result.returncode, output, failing
+
+
+def fail(reason: str, *, detail: str = "") -> int:
+    print(f"\n::error::PR test gate: {reason}")
+    print(f"\n  FAILED — {reason}\n")
+    if detail:
+        print(detail)
+    print(
+        "\n  A change to src/ has to arrive with a test that fails without it.\n"
+        "  If this pull request genuinely changes no behaviour — a pure refactor,\n"
+        "  a rename, a dependency bump — add the `no-test-gate` label and say why\n"
+        "  in the pull request body. The exemption is recorded, not silent.\n"
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="base ref or SHA")
+    parser.add_argument("--head", default="HEAD", help="head ref or SHA")
+    args = parser.parse_args()
+
+    if not Path(SRC_DIR).is_dir() or not Path(TEST_DIR).is_dir():
+        raise GateError(f"expected {SRC_DIR}/ and {TEST_DIR}/ in {Path.cwd()}")
+
+    base, head = args.base, args.head
+    src_changed = changed_files(base, head, SRC_DIR)
+    test_changed = changed_files(base, head, TEST_DIR)
+
+    print(f"  base {git('rev-parse', '--short', base).strip()}  head {git('rev-parse', '--short', head).strip()}")
+
+    if not src_changed:
+        print("\n  SKIPPED — no changes under src/. Nothing to demonstrate.\n")
+        return 0
+
+    print(f"\n  source files changed ({len(src_changed)}):")
+    for path in src_changed:
+        print(f"    {path}")
+
+    if not test_changed:
+        return fail(
+            "src/ changed but no test changed",
+            detail="  Changed without a test:\n" + "".join(f"    {p}\n" for p in src_changed),
+        )
+
+    added = added_test_names(base, head)
+    if not added:
+        return fail(
+            "test files changed but no new test was added",
+            detail=f"  Changed test files: {', '.join(test_changed)}\n"
+            "  The gate looks for added `def test_*`. Editing an existing\n"
+            "  test in place cannot show that the defect was ever present.\n",
+        )
+
+    print(f"\n  tests added ({len(added)}):")
+    for name in sorted(added):
+        print(f"    {name}")
+
+    # --- Half one: the new tests must fail against the base source. ----------
+    # Only src/ is reverted. Packaging and test fixtures stay at head so the
+    # single variable under test is the source change itself.
+    print("\n  [1/2] running the PR's tests against base source ...")
+    git("checkout", base, "--", SRC_DIR)
+    try:
+        code, output, failing = run_pytest(test_changed)
+    finally:
+        git("checkout", head, "--", SRC_DIR)
+
+    if code == 0:
+        return fail(
+            "every test passes without the patch",
+            detail="  The tests in this pull request pass against the base source,\n"
+            "  so they do not demonstrate that anything was broken.\n"
+            "  Write a test that fails first, then make it pass.\n",
+        )
+
+    proving = sorted(added & failing)
+    if not proving:
+        if not failing:
+            # Base could not even collect the tests — they reference API that
+            # only exists on head. That is the strongest possible signal.
+            print("  base run could not collect the tests (new API referenced).")
+            print("  accepted as evidence the tests require the patch.")
+        else:
+            return fail(
+                "no *added* test fails without the patch",
+                detail=f"  Failing on base: {', '.join(sorted(failing))}\n"
+                f"  Added by this PR: {', '.join(sorted(added))}\n"
+                "  Something failed on base, but nothing this pull request\n"
+                "  added. That is a pre-existing failure, not evidence.\n",
+            )
+    else:
+        print(f"  {len(proving)} added test(s) fail without the patch:")
+        for name in proving:
+            print(f"    {name}")
+
+    # --- Half two: everything must pass with the patch applied. -------------
+    print("\n  [2/2] running the same tests against the PR ...")
+    code, output, failing = run_pytest(test_changed)
+    if code != 0:
+        return fail(
+            "the tests do not pass with the patch applied",
+            detail=f"  Still failing: {', '.join(sorted(failing))}\n\n{output[-2000:]}",
+        )
+
+    print("\n  PASSED — the defect is demonstrated and the patch closes it.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except GateError as exc:
+        print(f"::error::PR test gate could not run: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/.github/workflows/test-gate.yml
+++ b/.github/workflows/test-gate.yml
@@ -1,0 +1,61 @@
+name: Test Gate
+
+# Every change to src/ must arrive with a test that fails without it. The gate
+# runs the pull request's own tests against the base source: at least one newly
+# added test has to fail there, and all of them have to pass once the patch is
+# applied. A test that passes either way proves nothing.
+#
+# Exemptions are deliberate and visible: Dependabot is skipped by author, and a
+# genuine no-behaviour-change pull request is skipped by the `no-test-gate`
+# label, which leaves the reason on the pull request instead of in a log.
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'no-test-gate')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # Full history: the gate diffs against the merge base and checks the
+          # base revision of src/ out in place.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Resolve merge base
+        run: |
+          BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          echo "BASE_SHA=$BASE" >> "$GITHUB_ENV"
+          echo "Comparing against $BASE (merge base with ${{ github.base_ref }})"
+
+      - name: Does the test prove the fix?
+        run: python .github/scripts/pr_test_gate.py --base "$BASE_SHA" --head HEAD
+
+  # Reports the exemption rather than leaving a silent gap in the checks list.
+  exempt:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'no-test-gate')
+    steps:
+      - name: Record the exemption
+        run: |
+          echo "::notice::Test gate skipped via the no-test-gate label."
+          echo "This pull request claims it changes no behaviour."
+          echo "That claim is the reviewer's to check."


### PR DESCRIPTION
A green test suite says the tests agree with the code. It does not say anything was ever broken. Those are different claims, and we shipped a release that relied on the weaker one — the config branch passed 381 tests with four stated requirements unbuilt.

This gate asks the other question.

```
  [1/2] running the PR's tests against base source ...
  10 added test(s) fail without the patch:
    test_key_name_reaches_list_elements
    test_bare_top_level_list
    test_subtree_below_the_cap_is_replaced_not_returned
    ...
  [2/2] running the same tests against the PR ...

  PASSED — the defect is demonstrated and the patch closes it.
```

## How it works

Revert **only** `src/` to the merge base, keep the pull request's tests and packaging, run the changed test files. Require at least one *added* test — parsed as `def test_*` out of the diff, not merely a changed file — to fail there. Then restore `src/` and require all of them to pass.

Reverting `src/` alone rather than the whole tree is deliberate: it keeps a version bump or a new dev dependency out of the measurement, so the only variable is the source change.

## What it rejects

| Case | Verdict |
|---|---|
| Merged PR #34 replayed | passes — 10 of its 12 added tests fail on base, the other 2 are regression guards |
| `src/` changed, no test touched | rejected |
| `src/` changed, test added that passes on base | rejected |
| Test file edited but no test added | rejected |

Validated against a real worktree and virtualenv before this branch existed, not reasoned about.

## Exemptions are visible, not silent

Dependabot skips by author. A pull request that genuinely changes no behaviour — a pure refactor, a rename — skips via the `no-test-gate` label. Bun's version auto-rejects with no hatch at all; a gate with no honest exemption gets routed around dishonestly instead. A second job reports the exemption so it shows in the checks list rather than leaving a gap that reads like a pass.

## Note on this pull request

It touches no `src/`, so the gate skips itself — which also smoke-tests the checkout, install, and merge-base resolution against a live pull request.

Not proposing this as a required check yet. Watch it run against one real behaviour-changing pull request first.

Source: Jarred Sumner on Bun's automation, The Pragmatic Engineer, 28 Jul 2026.