### PR TITLE
chore: 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "secretscreen"
-version = "0.5.0"
+version = "0.5.1"
 description = "Detect and redact secrets in key-value pairs, dicts, and environment variables. Library and CLI."
 readme = "README.md"
 license = "MIT"

--- a/src/secretscreen/__init__.py
+++ b/src/secretscreen/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "redact_pair",
 ]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Release bump so the #37 fix reaches PyPI — it has been sitting on `main` unreleased, since publishing is release-triggered.

## What 0.5.1 ships

**[#37](https://github.com/featurecreep-cron/secretscreen/pull/37) — a bare `secretscreen` no longer blocks forever at a terminal.** It fell through to `sys.stdin.read()`, which at an interactive TTY waits indefinitely: indistinguishable from a hang, and the first thing anyone types after installing. No FILE plus a TTY on stdin now prints the help and exits 2. An explicit `-` still reads the terminal, and pipes are unaffected.

Also on `main` since 0.5.0, neither user-facing: the Test Gate (#35) and a Dependabot actions bump.

## Version bump only

`pyproject.toml` and `src/secretscreen/__init__.py` both record the version and must agree with the tag.

`no-test-gate` applied — there is no behaviour change to write a failing test against, which is exactly what that label is for. Note it did not exist until now: `test-gate.yml` has referenced it since #35, so the documented exemption was unusable. Created with the workflow's own wording.